### PR TITLE
pimp readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 <p align="center"><code>chartmogul-ruby</code> provides convenient Ruby bindings for <a href="https://dev.chartmogul.com">ChartMogul's API</a>.</p>
 
-<br>
+<p align="center"><img src="https://travis-ci.com/chartmogul/chartmogul-ruby.svg?token=3psqw6c8KMDqfdGQ2x6d&branch=master"></p>
+
 <hr>
 
 <p align="center">


### PR DESCRIPTION
- add centered readme header with linked ChartMogul logo & TOC
- add MIT license text

Like so:
![screen shot 2016-06-27 at 16 15 23](https://cloud.githubusercontent.com/assets/90316/16382743/6343eeaa-3c82-11e6-8407-d7d923a1ec3f.png)
