### PR TITLE
Add MRR contraction to Metrics MRR entity

### DIFF
--- a/lib/chartmogul/metrics/mrr.rb
+++ b/lib/chartmogul/metrics/mrr.rb
@@ -5,8 +5,12 @@ module ChartMogul
 
       readonly_attr :date, type: :date
       readonly_attr :mrr
+
       readonly_attr :mrr_new_business
+
       readonly_attr :mrr_expansion
+      readonly_attr :mrr_contraction
+
       readonly_attr :mrr_churn
       readonly_attr :mrr_reactivation
     end

--- a/spec/chartmogul/metrics/mrr_spec.rb
+++ b/spec/chartmogul/metrics/mrr_spec.rb
@@ -13,11 +13,16 @@ describe ChartMogul::Metrics::MrrEntity, vcr: true, uses_api: true do
     entry = response[0]
 
     expect(entry).to be_kind_of(described_class)
+
     expect(entry.date).to be_kind_of(Date)
-    expect(entry.mrr).to_not be_nil
-    expect(entry.mrr_new_business).to_not be_nil
-    expect(entry.mrr_expansion).to_not be_nil
-    expect(entry.mrr_churn).to_not be_nil
-    expect(entry.mrr_reactivation).to_not be_nil
+    expect(entry.mrr).not_to be_nil
+
+    expect(entry.mrr_new_business).not_to be_nil
+
+    expect(entry.mrr_expansion).not_to be_nil
+    expect(entry.mrr_contraction).not_to be_nil
+
+    expect(entry.mrr_churn).not_to be_nil
+    expect(entry.mrr_reactivation).not_to be_nil
   end
 end


### PR DESCRIPTION
`mrr_contraction` was missing from the response for `ChartMogul::Metrics.mrr`
This PR adds it
