### PR TITLE
Search customer by external_id (Import API)

### DIFF
--- a/fixtures/vcr_cassettes/ChartMogul_Import_Customer/_find_by_external_id/when_external_id_is_provided/returns_matching_user_if_exists.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Import_Customer/_find_by_external_id/when_external_id_is_provided/returns_matching_user_if_exists.yml
@@ -1,0 +1,102 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/import/customers
+    body:
+      encoding: UTF-8
+      string: '{"data_source_uuid":"ds_154b9620-a22a-478a-8b44-198d11cc9a85","external_id":"X1234","name":"Test
+        Customer","email":"test@example.com","company":null,"country":"DE","state":null,"city":"Berlin","zip":null}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+  response:
+    status:
+      code: 201
+      message:
+    headers:
+      server:
+      - nginx/1.9.10
+      date:
+      - Mon, 06 Jun 2016 15:26:39 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"2bb61213c73b74bf7e3094b3a2814b1c"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 7a43eb0b-0099-4cef-b620-a6ac687ace2f
+      x-runtime:
+      - '0.202425'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"uuid":"cus_c4babf63-3eb9-4125-8687-2a0d781b0af2","external_id":"X1234","name":"Test
+        Customer","company":"","email":"test@example.com","city":"Berlin","state":"","country":"DE","zip":"","data_source_uuid":"ds_154b9620-a22a-478a-8b44-198d11cc9a85"}'
+    http_version:
+  recorded_at: Mon, 06 Jun 2016 15:26:39 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/import/customers?external_id=X1234
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.9.10
+      date:
+      - Mon, 06 Jun 2016 15:26:40 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"f8b194be146b71827424808d2de63994"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - aa0a64af-9cd4-4b7d-9d43-d3b7c08ac7d1
+      x-runtime:
+      - '0.020597'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"customers":[{"uuid":"cus_c4babf63-3eb9-4125-8687-2a0d781b0af2","external_id":"X1234","name":"Test
+        Customer","company":"","email":"test@example.com","city":"Berlin","state":"","country":"DE","zip":"","data_source_uuid":"ds_154b9620-a22a-478a-8b44-198d11cc9a85"}],"current_page":1,"total_pages":1}'
+    http_version:
+  recorded_at: Mon, 06 Jun 2016 15:26:40 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/ChartMogul_Import_Customer/_find_by_external_id/when_external_id_is_provided/returns_nil_if_customer_does_not_exist.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Import_Customer/_find_by_external_id/when_external_id_is_provided/returns_nil_if_customer_does_not_exist.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/import/customers
+    body:
+      encoding: UTF-8
+      string: '{"data_source_uuid":"ds_154b9620-a22a-478a-8b44-198d11cc9a85","external_id":"X1234","name":"Test
+        Customer","email":"test@example.com","company":null,"country":"DE","state":null,"city":"Berlin","zip":null}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+  response:
+    status:
+      code: 201
+      message:
+    headers:
+      server:
+      - nginx/1.9.10
+      date:
+      - Mon, 06 Jun 2016 15:26:39 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"2bb61213c73b74bf7e3094b3a2814b1c"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 7a43eb0b-0099-4cef-b620-a6ac687ace2f
+      x-runtime:
+      - '0.202425'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"uuid":"cus_c4babf63-3eb9-4125-8687-2a0d781b0af2","external_id":"X1234","name":"Test
+        Customer","company":"","email":"test@example.com","city":"Berlin","state":"","country":"DE","zip":"","data_source_uuid":"ds_154b9620-a22a-478a-8b44-198d11cc9a85"}'
+    http_version:
+  recorded_at: Mon, 06 Jun 2016 15:26:39 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/import/customers?external_id=nope
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.9.10
+      date:
+      - Mon, 06 Jun 2016 15:26:40 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"f8b194be146b71827424808d2de63994"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - aa0a64af-9cd4-4b7d-9d43-d3b7c08ac7d1
+      x-runtime:
+      - '0.020597'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"customers":[]}'
+    http_version:
+  recorded_at: Mon, 06 Jun 2016 15:26:40 GMT
+recorded_with: VCR 3.0.3

--- a/lib/chartmogul/import/customer.rb
+++ b/lib/chartmogul/import/customer.rb
@@ -15,12 +15,15 @@ module ChartMogul
       writeable_attr :state
       writeable_attr :city
       writeable_attr :zip
-
       writeable_attr :data_source_uuid
 
       include API::Actions::All
       include API::Actions::Create
       include API::Actions::Destroy
+
+      def self.find_by_external_id(external_id)
+        all(external_id: external_id).first
+      end
 
       def subscriptions(options = {})
         @subscriptions ||= Subscription.all(uuid, options)

--- a/spec/chartmogul/import/customer_spec.rb
+++ b/spec/chartmogul/import/customer_spec.rb
@@ -86,6 +86,21 @@ describe ChartMogul::Import::Customer do
     end
   end
 
+  describe '.find_by_external_id', vcr: true do
+    context 'when external_id is provided' do
+      it 'returns matching user if exists', uses_api: true do
+        result = ChartMogul::Import::Customer.find_by_external_id('X1234')
+        expect(result).not_to be_nil
+        expect(result.external_id).to eq(attrs[:external_id])
+      end
+
+      it 'returns nil if customer does not exist', uses_api: true do
+        result = ChartMogul::Import::Customer.find_by_external_id('nope')
+        expect(result).to be_nil
+      end
+    end
+  end
+
   describe 'API Interactions', vcr: true do
     it 'correctly interracts with the API', uses_api: true do
       ds = ChartMogul::Import::DataSource.create!(name: 'Customer Test Data Source')


### PR DESCRIPTION
I've included a very simple `.find_by_external_id` method in `Import::Customer`.

This would avoid the following pattern for retrieving one particular customer:
```
customer = ChartMogul::Import::Customer.all(external_id:"cus_0001").first
# do something with customer object (e.g. cancel subscription)
```
