### PR TITLE
Add support for lead_created_at and free_trial_started_at fields

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # chartmogul-ruby Change Log
 
+## Version 0.1.3 - 8 November 2016
+- Add support for lead_created_at and free_trial_started_at fields to work with Leads and Trials charts
+
 ## Version 0.1.2 - 13 July 2016
 - Fix bug preventing cancellation of subscriptions [#22]
 

--- a/fixtures/vcr_cassettes/ChartMogul_Import_Customer/API_Interactions/correctly_interracts_with_the_API.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Import_Customer/API_Interactions/correctly_interracts_with_the_API.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: '{"name":"Customer Test Data Source"}'
     headers:
       User-Agent:
-      - Faraday v0.9.1
+      - Faraday v0.9.2
       Content-Type:
       - application/json
       Authorization:
@@ -19,9 +19,9 @@ http_interactions:
       message: 
     headers:
       server:
-      - nginx/1.9.10
+      - nginx/1.10.1
       date:
-      - Mon, 06 Jun 2016 15:26:39 GMT
+      - Tue, 08 Nov 2016 08:57:33 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -35,31 +35,31 @@ http_interactions:
       x-content-type-options:
       - nosniff
       etag:
-      - W/"efc297a7a44e439e9e557cdb452df1f4"
+      - W/"bcfee5f9180970835929930b05411ff4"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 2a244394-b7a8-4a47-bb66-b5122c819ab2
+      - 9505cefe-9a7a-46af-a173-7a686cf46800
       x-runtime:
-      - '0.334024'
+      - '0.461858'
       strict-transport-security:
       - max-age=15768000
     body:
       encoding: UTF-8
-      string: '{"uuid":"ds_154b9620-a22a-478a-8b44-198d11cc9a85","name":"Customer
-        Test Data Source","created_at":"2016-06-06T15:26:39.448Z","status":"never_imported"}'
+      string: '{"uuid":"ds_632433ee-a591-11e6-aa29-ff9ccc9a74aa","name":"Customer
+        Test Data Source","created_at":"2016-11-08T08:57:33.304Z","status":"never_imported"}'
     http_version: 
-  recorded_at: Mon, 06 Jun 2016 15:26:39 GMT
+  recorded_at: Tue, 08 Nov 2016 08:57:33 GMT
 - request:
     method: post
     uri: https://api.chartmogul.com/v1/import/customers
     body:
       encoding: UTF-8
-      string: '{"data_source_uuid":"ds_154b9620-a22a-478a-8b44-198d11cc9a85","external_id":"X1234","name":"Test
-        Customer","email":"test@example.com","company":null,"country":"DE","state":null,"city":"Berlin","zip":null}'
+      string: '{"external_id":"X1234","name":"Test Customer","email":"test@example.com","country":"DE","city":"Berlin","data_source_uuid":"ds_632433ee-a591-11e6-aa29-ff9ccc9a74aa","lead_created_at":"2016-10-01
+        23:55:00 UTC","free_trial_started_at":"2016-10-12 11:12:00 UTC"}'
     headers:
       User-Agent:
-      - Faraday v0.9.1
+      - Faraday v0.9.2
       Content-Type:
       - application/json
       Authorization:
@@ -70,9 +70,9 @@ http_interactions:
       message: 
     headers:
       server:
-      - nginx/1.9.10
+      - nginx/1.10.1
       date:
-      - Mon, 06 Jun 2016 15:26:39 GMT
+      - Tue, 08 Nov 2016 08:57:33 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -86,21 +86,21 @@ http_interactions:
       x-content-type-options:
       - nosniff
       etag:
-      - W/"2bb61213c73b74bf7e3094b3a2814b1c"
+      - W/"edb1e5e3324d47803eccb229a21363df"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 7a43eb0b-0099-4cef-b620-a6ac687ace2f
+      - bf049e2c-b057-4d90-85bf-f90c9ca98b31
       x-runtime:
-      - '0.202425'
+      - '0.158973'
       strict-transport-security:
       - max-age=15768000
     body:
       encoding: UTF-8
-      string: '{"uuid":"cus_c4babf63-3eb9-4125-8687-2a0d781b0af2","external_id":"X1234","name":"Test
-        Customer","company":"","email":"test@example.com","city":"Berlin","state":"","country":"DE","zip":"","data_source_uuid":"ds_154b9620-a22a-478a-8b44-198d11cc9a85"}'
+      string: '{"uuid":"cus_709bf73d-dc7c-4fb3-825d-a32c7fe5be16","external_id":"X1234","name":"Test
+        Customer","company":"","email":"test@example.com","city":"Berlin","state":"","country":"DE","zip":"","lead_created_at":"2016-10-01T23:55:00.000Z","free_trial_started_at":"2016-10-12T11:12:00.000Z","data_source_uuid":"ds_632433ee-a591-11e6-aa29-ff9ccc9a74aa"}'
     http_version: 
-  recorded_at: Mon, 06 Jun 2016 15:26:39 GMT
+  recorded_at: Tue, 08 Nov 2016 08:57:33 GMT
 - request:
     method: get
     uri: https://api.chartmogul.com/v1/import/customers
@@ -109,7 +109,9 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.9.1
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
       Authorization:
       - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
   response:
@@ -118,9 +120,9 @@ http_interactions:
       message: 
     headers:
       server:
-      - nginx/1.9.10
+      - nginx/1.10.1
       date:
-      - Mon, 06 Jun 2016 15:26:40 GMT
+      - Tue, 08 Nov 2016 08:57:34 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -134,30 +136,30 @@ http_interactions:
       x-content-type-options:
       - nosniff
       etag:
-      - W/"f8b194be146b71827424808d2de63994"
+      - W/"eb861872d3bd01a055485e96ccf38898"
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - aa0a64af-9cd4-4b7d-9d43-d3b7c08ac7d1
+      - 32f87d7c-f944-405d-a87c-2195f175940a
       x-runtime:
-      - '0.020597'
+      - '0.022802'
       strict-transport-security:
       - max-age=15768000
     body:
       encoding: UTF-8
-      string: '{"customers":[{"uuid":"cus_c4babf63-3eb9-4125-8687-2a0d781b0af2","external_id":"X1234","name":"Test
-        Customer","company":"","email":"test@example.com","city":"Berlin","state":"","country":"DE","zip":"","data_source_uuid":"ds_154b9620-a22a-478a-8b44-198d11cc9a85"}],"current_page":1,"total_pages":1}'
+      string: '{"customers":[{"uuid":"cus_709bf73d-dc7c-4fb3-825d-a32c7fe5be16","external_id":"X1234","name":"Test
+        Customer","company":"","email":"test@example.com","city":"Berlin","state":"","country":"DE","zip":"","lead_created_at":"2016-10-01T23:55:00.000Z","free_trial_started_at":"2016-10-12T11:12:00.000Z","data_source_uuid":"ds_632433ee-a591-11e6-aa29-ff9ccc9a74aa"}],"current_page":1,"total_pages":1}'
     http_version: 
-  recorded_at: Mon, 06 Jun 2016 15:26:40 GMT
+  recorded_at: Tue, 08 Nov 2016 08:57:34 GMT
 - request:
     method: delete
-    uri: https://api.chartmogul.com/v1/import/customers/cus_c4babf63-3eb9-4125-8687-2a0d781b0af2
+    uri: https://api.chartmogul.com/v1/import/customers/cus_709bf73d-dc7c-4fb3-825d-a32c7fe5be16
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.9.1
+      - Faraday v0.9.2
       Authorization:
       - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
   response:
@@ -166,9 +168,9 @@ http_interactions:
       message: 
     headers:
       server:
-      - nginx/1.9.10
+      - nginx/1.10.1
       date:
-      - Mon, 06 Jun 2016 15:26:40 GMT
+      - Tue, 08 Nov 2016 08:57:34 GMT
       connection:
       - close
       x-frame-options:
@@ -180,16 +182,16 @@ http_interactions:
       cache-control:
       - no-cache
       x-request-id:
-      - accd161f-de8b-426f-9a44-4b142a69ccc4
+      - f163488f-bbea-4937-897b-ee08b69a4560
       x-runtime:
-      - '0.022023'
+      - '0.015696'
       strict-transport-security:
       - max-age=15768000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 06 Jun 2016 15:26:40 GMT
+  recorded_at: Tue, 08 Nov 2016 08:57:34 GMT
 - request:
     method: get
     uri: https://api.chartmogul.com/v1/import/customers
@@ -198,7 +200,9 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.9.1
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
       Authorization:
       - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
   response:
@@ -207,9 +211,9 @@ http_interactions:
       message: 
     headers:
       server:
-      - nginx/1.9.10
+      - nginx/1.10.1
       date:
-      - Mon, 06 Jun 2016 15:26:50 GMT
+      - Tue, 08 Nov 2016 08:57:34 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -227,14 +231,14 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - 955582ac-5fe6-43c4-b0e8-f36fa27fdd57
+      - 770d6629-03d8-4f55-8bec-dde047828e7e
       x-runtime:
-      - '0.011286'
+      - '0.019712'
       strict-transport-security:
       - max-age=15768000
     body:
       encoding: UTF-8
       string: '{"customers":[],"current_page":1,"total_pages":0}'
     http_version: 
-  recorded_at: Mon, 06 Jun 2016 15:26:50 GMT
+  recorded_at: Tue, 08 Nov 2016 08:57:34 GMT
 recorded_with: VCR 3.0.3

--- a/lib/chartmogul/import/customer.rb
+++ b/lib/chartmogul/import/customer.rb
@@ -16,6 +16,8 @@ module ChartMogul
       writeable_attr :city
       writeable_attr :zip
       writeable_attr :data_source_uuid
+      writeable_attr :lead_created_at, type: :time
+      writeable_attr :free_trial_started_at, type: :time
 
       include API::Actions::All
       include API::Actions::Create

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,3 +1,3 @@
 module ChartMogul
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/spec/chartmogul/import/customer_spec.rb
+++ b/spec/chartmogul/import/customer_spec.rb
@@ -10,7 +10,9 @@ describe ChartMogul::Import::Customer do
       city: 'Berlin',
       state: 'BE',
       country: 'DE',
-      zip: '10115'
+      zip: '10115',
+      lead_created_at: Time.utc(2016,10,1).to_s,
+      free_trial_started_at: Time.utc(2016,10,2).to_s
     }
   end
 
@@ -44,9 +46,16 @@ describe ChartMogul::Import::Customer do
     it 'sets the country attribute' do
       expect(subject.country).to eq('DE')
     end
-
     it 'sets the zip attribute' do
       expect(subject.zip).to eq('10115')
+    end
+
+    it 'sets the lead_created_at attribute' do
+      expect(subject.lead_created_at).to eq(Time.utc(2016,10,1).to_s)
+    end
+
+    it 'sets the free_trial_started_at attribute' do
+      expect(subject.free_trial_started_at).to eq(Time.utc(2016,10,2).to_s)
     end
   end
 
@@ -84,6 +93,14 @@ describe ChartMogul::Import::Customer do
     it 'sets the zip attribute' do
       expect(subject.zip).to eq('10115')
     end
+
+    it 'sets the lead_created_at attribute' do
+      expect(subject.lead_created_at).to eq(Time.utc(2016,10,1))
+    end
+
+    it 'sets the free_trial_started_at attribute' do
+      expect(subject.free_trial_started_at).to eq(Time.utc(2016,10,2))
+    end
   end
 
   describe '.find_by_external_id', vcr: true do
@@ -102,6 +119,8 @@ describe ChartMogul::Import::Customer do
   end
 
   describe 'API Interactions', vcr: true do
+    let(:lead_created_at) { Time.utc(2016,10,1,23,55) }
+    let(:free_trial_started_at) { Time.utc(2016,10,12,11,12) }
     it 'correctly interracts with the API', uses_api: true do
       ds = ChartMogul::Import::DataSource.create!(name: 'Customer Test Data Source')
 
@@ -111,7 +130,9 @@ describe ChartMogul::Import::Customer do
         data_source_uuid: ds.uuid,
         email: 'test@example.com',
         city: 'Berlin',
-        country: 'DE'
+        country: 'DE',
+        lead_created_at: lead_created_at.to_s,
+        free_trial_started_at: free_trial_started_at.to_s
       )
 
       customers = ChartMogul::Import::Customer.all
@@ -124,6 +145,8 @@ describe ChartMogul::Import::Customer do
       expect(customers[0].email).to eq('test@example.com')
       expect(customers[0].city).to eq('Berlin')
       expect(customers[0].country).to eq('DE')
+      expect(customers[0].lead_created_at).to eq(lead_created_at)
+      expect(customers[0].free_trial_started_at).to eq(free_trial_started_at)
 
       customer.destroy!
 


### PR DESCRIPTION
Now you can send `lead_created_at` and `free_trial_started_at` attributes to assist with ChartMogul's Leads and Trials features. [More information on this here](https://dev.chartmogul.com/v1.0/docs/tracking-leads-and-free-trials-using-the-api).