### PR TITLE
Handle errors of APIResource if exception.response is nil

### DIFF
--- a/fixtures/vcr_cassettes/ChartMogul_Enrichment_Customer/API_Interactions/raises_401_if_invalid_credentials.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Enrichment_Customer/API_Interactions/raises_401_if_invalid_credentials.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/customers?per_page=10
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.10.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic ZHVtbXktdG9rZW46ZHVtbXktdG9rZW4=
+  response:
+    status:
+      code: 401
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Wed, 28 Dec 2016 17:04:19 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '63'
+      connection:
+      - close
+      status:
+      - 401 Unauthorized
+    body:
+      encoding: UTF-8
+      string: '{"code":401,"message":"No valid API key provided","param":null}'
+    http_version: 
+  recorded_at: Wed, 28 Dec 2016 17:04:19 GMT
+recorded_with: VCR 3.0.3

--- a/lib/chartmogul.rb
+++ b/lib/chartmogul.rb
@@ -12,6 +12,7 @@ require "chartmogul/errors/not_found_error"
 require "chartmogul/errors/configuration_error"
 require "chartmogul/errors/resource_invalid_error"
 require "chartmogul/errors/schema_invalid_error"
+require "chartmogul/errors/unauthorized_error"
 
 require "chartmogul/config_attributes"
 require "chartmogul/configuration"

--- a/lib/chartmogul/api_resource.rb
+++ b/lib/chartmogul/api_resource.rb
@@ -41,6 +41,9 @@ module ChartMogul
       when 400
         message = "JSON schema validation hasn't passed."
         raise ChartMogul::SchemaInvalidError.new(message, http_status: 400, response: response)
+      when 401
+        message = "Unauthorized request"
+        raise ChartMogul::UnauthorizedError.new(message, http_status: 401, response: response)
       when 403
         message = "The requested action is forbidden."
         raise ChartMogul::ForbiddenError.new(message, http_status: 403, response: response)

--- a/lib/chartmogul/api_resource.rb
+++ b/lib/chartmogul/api_resource.rb
@@ -42,7 +42,7 @@ module ChartMogul
         message = "JSON schema validation hasn't passed."
         raise ChartMogul::SchemaInvalidError.new(message, http_status: 400, response: response)
       when 401
-        message = "Unauthorized request"
+        message = 'No valid API key provided'
         raise ChartMogul::UnauthorizedError.new(message, http_status: 401, response: response)
       when 403
         message = "The requested action is forbidden."

--- a/lib/chartmogul/api_resource.rb
+++ b/lib/chartmogul/api_resource.rb
@@ -29,6 +29,12 @@ module ChartMogul
     def self.handling_errors
       yield
     rescue Faraday::ClientError => exception
+      exception.response ? handle_request_error(exception) : handle_other_error(exception)
+    rescue => exception
+      handle_other_error(exception)
+    end
+
+    def self.handle_request_error(exception)
       response = exception.response[:body]
       http_status = exception.response[:status]
       case http_status
@@ -48,7 +54,9 @@ module ChartMogul
         message = "#{resource_name} request error has occurred."
         raise ChartMogul::ChartMogulError.new(message, http_status: http_status, response: response)
       end
-    rescue => exception
+    end
+
+    def self.handle_other_error(exception)
       raise ChartMogul::ChartMogulError.new(exception.message)
     end
 

--- a/lib/chartmogul/errors/unauthorized_error.rb
+++ b/lib/chartmogul/errors/unauthorized_error.rb
@@ -1,0 +1,4 @@
+module ChartMogul
+  class UnauthorizedError < ChartMogulError
+  end
+end

--- a/spec/chartmogul/enrichment/customer_spec.rb
+++ b/spec/chartmogul/enrichment/customer_spec.rb
@@ -122,5 +122,11 @@ describe ChartMogul::Enrichment::Customer do
         customer.update!
       end.to raise_error(ChartMogul::ResourceInvalidError, 'The Customer could not be created or updated.')
     end
+
+    it 'raises 401 if invalid credentials', uses_api: true do
+      expect do
+        described_class.all(per_page: 10)
+      end.to raise_error(ChartMogul::UnauthorizedError, 'Unauthorized request')
+    end
   end
 end

--- a/spec/chartmogul/enrichment/customer_spec.rb
+++ b/spec/chartmogul/enrichment/customer_spec.rb
@@ -126,7 +126,7 @@ describe ChartMogul::Enrichment::Customer do
     it 'raises 401 if invalid credentials', uses_api: true do
       expect do
         described_class.all(per_page: 10)
-      end.to raise_error(ChartMogul::UnauthorizedError, 'Unauthorized request')
+      end.to raise_error(ChartMogul::UnauthorizedError, 'No valid API key provided')
     end
   end
 end


### PR DESCRIPTION
1. Problem: when I have no internet connection and try to get data from CM using this gem, I not handled error:
```
>>  ChartMogul::Enrichment::Customer.all(page: 1, per_page: 50)
NoMethodError: undefined method `[]' for nil:NilClass
```

Reason: exception.response inside of a rescue block is nil => another exception when trying to work with it as with hash:
```
>> (ChartMogul::Enrichment::Customers) »  exception.response
=> nil
```

Solution: change logic of rescue block depending on presence of `exception.response` 

2. Add custom error handler for "401 Unauthorized"