### PR TITLE
Add support for new endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.swp

--- a/fixtures/vcr_cassettes/ChartMogul_Import_DataSource/API_Interactions/retrieves_existing_data_source_matching_uuid.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Import_DataSource/API_Interactions/retrieves_existing_data_source_matching_uuid.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/import/data_sources
+    body:
+      encoding: UTF-8
+      string: '{"name":"TestDS"}'
+    headers:
+      User-Agent:
+      - Faraday v0.10.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic ZHVtbXktdG9rZW46ZHVtbXktdG9rZW4=
+  response:
+    status:
+      code: 201
+      message:
+    headers:
+      server:
+      - nginx/1.9.10
+      date:
+      - Sun, 05 Jun 2016 18:52:01 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"5621b5bd639d8cf3876eddd3c3617ee5"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 67b3f0f2-9b9a-4bae-b631-578db1d7158b
+      x-runtime:
+      - '0.435113'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"uuid":"ds_5ee8bf93-b0b4-4722-8a17-6b624a3af072","name":"TestDS","created_at":"2016-06-05T18:52:00.931Z","status":"never_imported"}'
+    http_version:
+  recorded_at: Tue, 03 Jan 2017 22:49:40 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/data_sources/ds_5ee8bf93-b0b4-4722-8a17-6b624a3af072
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.10.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic ZHVtbXktdG9rZW46ZHVtbXktdG9rZW4=
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.9.10
+      date:
+      - Sun, 05 Jun 2016 18:52:01 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"5621b5bd639d8cf3876eddd3c3617ee5"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 67b3f0f2-9b9a-4bae-b631-578db1d7158b
+      x-runtime:
+      - '0.435113'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"uuid":"ds_5ee8bf93-b0b4-4722-8a17-6b624a3af072","name":"TestDS","system": "Import API", "created_at":"2016-06-05T18:52:00.931Z","status":"never_imported"}'
+    http_version:
+  recorded_at: Tue, 03 Jan 2017 22:49:40 GMT
+recorded_with: VCR 3.0.3

--- a/lib/chartmogul/import/data_source.rb
+++ b/lib/chartmogul/import/data_source.rb
@@ -14,6 +14,11 @@ module ChartMogul
       include API::Actions::All
       include API::Actions::Create
       include API::Actions::Destroy
+      include API::Actions::Custom
+
+      def self.retrieve(uuid)
+        custom!(:get, "/v1/data_sources/#{uuid}")
+      end
     end
   end
 end

--- a/spec/chartmogul/import/data_source_spec.rb
+++ b/spec/chartmogul/import/data_source_spec.rb
@@ -72,5 +72,13 @@ describe ChartMogul::Import::DataSource do
       ds.send(:set_uuid, '1234-a-uuid-that-doesnt-exist')
       expect { ds.destroy! }.to raise_error(ChartMogul::NotFoundError)
     end
+
+    it 'retrieves existing data source matching uuid', uses_api: true do
+      ds = ChartMogul::Import::DataSource.create!(name: 'TestDS')
+      ds.send(:set_uuid, 'ds_5ee8bf93-b0b4-4722-8a17-6b624a3af072')
+
+      data_source = described_class.retrieve(ds.uuid)
+      expect(data_source).to be
+    end
   end
 end


### PR DESCRIPTION
This pull request adds support for new ChartMogul API endpoints:

- GET /v1/data_sources/:uuid
- GET /v1/plans
- PATCH /v1/plans/:uuid
- DELETE /v1/plans/:uuid
- GET /v1/customers/:uuid