### PR TITLE
Pageable

### DIFF
--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/can_page_through_search_endpoint.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/can_page_through_search_endpoint.yml
@@ -1,0 +1,43 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/customers/search?email=adam%40smith.com&page=2&per_page=1
+    body:
+      encoding: UTF-8
+      string: '{}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.9.10
+      date:
+      - Wed, 29 Jun 2016 12:47:11 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '740'
+      connection:
+      - close
+      status:
+      - 200 OK
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"entries":[{"id":20268060,"uuid":"cus_07393ece-aab1-4255-8bcd-0ef11e24b047","external_id":"cus_0001","name":"Adam
+        Smith","email":"adam@smith.com","status":"Cancelled","customer-since":"2016-05-01T12:00:00+00:00","attributes":{"tags":["another-tag"],"custom":{"string_key":"Another
+        String Value","integer_key":"5678","timestamp_key":"2016-02-01 00:00:00 UTC","boolean_key":"f"}},"address":{"country":"United
+        States","state":null,"city":"New York","address_line1":null,"address_line2":null,"address_zip":""},"mrr":0,"arr":0,"billing-system-url":null,"chartmogul-url":"https://app.chartmogul.com/#customers/cus_07393ece-aab1-4255-8bcd-0ef11e24b047-Adam_Smith","billing-system-type":"ImportApi","currency":"USD","currency-sign":"$"}],"has_more":false,"per_page":1,"page":2}'
+    http_version:
+  recorded_at: Wed, 29 Jun 2016 12:47:11 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/ChartMogul_Subscription/API_Interactions/has_multiple_aliases.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Subscription/API_Interactions/has_multiple_aliases.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/import/customers/cus_510b1395-4fe8-4d35-ae23-0e61f9a51e33/subscriptions?page=1&per_page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic YmIzN2I0Njk5NjNlMjhlYjY2MjA1ZWYzZmU1MWQ1NmM6ZmM1YjQxYzM3YTNlZTcwYjQyN2UwYzU1ODg2NzA2ZmQ=
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.9.10
+      date:
+      - Thu, 23 Jun 2016 20:46:07 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"797037ae5a33dcae7de46e23dfdd4ec7"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - efa1a67e-37e8-4ac3-bce7-8d11f33d0e8c
+      x-runtime:
+      - '0.026716'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"customer_uuid":"cus_510b1395-4fe8-4d35-ae23-0e61f9a51e33","subscriptions":[{"uuid":"sub_9b3ccf25-4613-4af6-84b3-12026cfa4b7c","external_id":"test_cus_sub_ext_id","cancellation_dates":[],"plan_uuid":"pl_06ea83a9-f8c8-4ddd-a980-9ceffd27f107","data_source_uuid":"ds_55ab11fb-53e6-4468-aa95-bd582f14cac6"}],"current_page":1,"total_pages":1}'
+    http_version:
+  recorded_at: Thu, 23 Jun 2016 20:46:07 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/import/customers/cus_510b1395-4fe8-4d35-ae23-0e61f9a51e33/subscriptions?page=2&per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic YmIzN2I0Njk5NjNlMjhlYjY2MjA1ZWYzZmU1MWQ1NmM6ZmM1YjQxYzM3YTNlZTcwYjQyN2UwYzU1ODg2NzA2ZmQ=
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.9.10
+      date:
+      - Thu, 23 Jun 2016 20:46:07 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"797037ae5a33dcae7de46e23dfdd4ec7"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - efa1a67e-37e8-4ac3-bce7-8d11f33d0e8c
+      x-runtime:
+      - '0.026716'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"customer_uuid":"cus_510b1395-4fe8-4d35-ae23-0e61f9a51e33","subscriptions":[{"uuid":"sub_9b3ccf25-4613-4af6-84b3-12026cfa4b7c","external_id":"test_cus_sub_ext_id","cancellation_dates":[],"plan_uuid":"pl_06ea83a9-f8c8-4ddd-a980-9ceffd27f107","data_source_uuid":"ds_55ab11fb-53e6-4468-aa95-bd582f14cac6"}],"current_page":2,"total_pages":2}'
+    http_version:
+  recorded_at: Thu, 23 Jun 2016 20:46:07 GMT
+recorded_with: VCR 3.0.3

--- a/lib/chartmogul/api/actions/all.rb
+++ b/lib/chartmogul/api/actions/all.rb
@@ -14,12 +14,7 @@ module ChartMogul
               end
             end
             json = ChartMogul::Utils::JSONParser.parse(resp.body)
-
-            if resource_root_key && json.key?(resource_root_key)
-              json[resource_root_key].map { |attributes| new_from_json(attributes) }
-            else
-              new_from_json(json)
-            end
+            new_from_json(json)
           end
         end
       end

--- a/lib/chartmogul/api/actions/custom.rb
+++ b/lib/chartmogul/api/actions/custom.rb
@@ -28,12 +28,7 @@ module ChartMogul
 
           def custom!(http_method, http_path, body_data = {})
             json = custom_without_assign!(http_method, http_path, body_data)
-
-            if resource_root_key && json.key?(resource_root_key)
-              json[resource_root_key].map { |attributes| new_from_json(attributes) }
-            else
-              new_from_json(json)
-            end
+            new_from_json(json)
           end
         end
       end

--- a/lib/chartmogul/api_resource.rb
+++ b/lib/chartmogul/api_resource.rb
@@ -17,7 +17,7 @@ module ChartMogul
     def self.set_resource_root_key(root_key)
       @resource_root_key = root_key
     end
-
+    
     def self.connection
       @connection ||= Faraday.new(url: ChartMogul::API_BASE) do |faraday|
         faraday.use Faraday::Request::BasicAuthentication, ChartMogul.account_token, ChartMogul.secret_key

--- a/lib/chartmogul/concerns/entries.rb
+++ b/lib/chartmogul/concerns/entries.rb
@@ -8,13 +8,12 @@ module ChartMogul
           if @resource_root_key.nil?
             @resource_root_key = :entries
           end
-          writeable_attr @resource_root_key, default: []
+          readonly_attr @resource_root_key, default: []
 
           include API::Actions::All
-          
+
           include Enumerable
-          def_delegators @resource_root_key, :each, :[], :<<, :size, :length
-          def_delegators @resource_root_key, :empty?, :first
+          def_delegators @resource_root_key, :each, :[], :<<, :size, :length, :empty?, :first
 
           resource_root_key = @resource_root_key.to_s
           base.send :define_method, "set_" + resource_root_key do |entries|

--- a/lib/chartmogul/customer.rb
+++ b/lib/chartmogul/customer.rb
@@ -45,8 +45,8 @@ module ChartMogul
       custom!(:get, "/v1/customers/#{uuid}")
     end
 
-    def self.search(email)
-      Customers.search(email)
+    def self.search(email, options = {})
+      Customers.search(email, options)
     end
 
     def self.find_by_external_id(external_id)
@@ -147,9 +147,9 @@ module ChartMogul
 
     set_entry_class Customer
 
-    def self.search(email)
+    def self.search(email, options = {})
       path = ChartMogul::ResourcePath.new('/v1/customers/search')
-      custom!(:get, path.apply_with_get_params(email: email))
+      custom!(:get, path.apply_with_get_params(options.merge(email: email)))
     end
   end
 end

--- a/lib/chartmogul/customer_invoices.rb
+++ b/lib/chartmogul/customer_invoices.rb
@@ -24,10 +24,11 @@ module ChartMogul
       super(options.merge(customer_uuid: customer_uuid))
     end
 
-    def_delegators :invoices, :each, :[], :<<, :size, :length
+    def_delegators :invoices, :each, :[], :<<, :size, :length, :empty?, :first
 
     private
 
+    # TODO: replace with Entries concern?
     def set_invoices(invoices_attributes)
       @invoices = invoices_attributes.map.with_index do |invoice_attributes, index|
         existing_invoice = invoices[index]

--- a/lib/chartmogul/customer_invoices.rb
+++ b/lib/chartmogul/customer_invoices.rb
@@ -14,6 +14,7 @@ module ChartMogul
 
     include API::Actions::All
     include API::Actions::Create
+    include Concerns::Pageable2
 
     def serialize_invoices
       map(&:serialize_for_write)

--- a/lib/chartmogul/data_source.rb
+++ b/lib/chartmogul/data_source.rb
@@ -2,7 +2,6 @@ module ChartMogul
   class DataSource < APIResource
     set_resource_name 'Data Source'
     set_resource_path '/v1/data_sources'
-    set_resource_root_key :data_sources
 
     readonly_attr :uuid
     readonly_attr :status
@@ -19,5 +18,21 @@ module ChartMogul
     def self.retrieve(uuid)
       custom!(:get, "/v1/data_sources/#{uuid}")
     end
+
+    def self.all(options = {})
+      DataSources.all(options)
+    end
+  end
+
+
+  class DataSources < APIResource
+    set_resource_name 'Data Sources'
+    set_resource_path '/v1/data_sources'
+
+    set_resource_root_key :data_sources
+
+    include Concerns::Entries
+
+    set_entry_class DataSource
   end
 end

--- a/lib/chartmogul/plan.rb
+++ b/lib/chartmogul/plan.rb
@@ -25,7 +25,7 @@ module ChartMogul
       Plans.all(options)
     end
   end
-
+  
 
   class Plans < APIResource
     set_resource_name 'Plans'

--- a/lib/chartmogul/plan.rb
+++ b/lib/chartmogul/plan.rb
@@ -2,7 +2,6 @@ module ChartMogul
   class Plan < APIResource
     set_resource_name 'Plan'
     set_resource_path '/v1/plans'
-    set_resource_root_key :plans
 
     readonly_attr :uuid
 
@@ -13,7 +12,6 @@ module ChartMogul
 
     writeable_attr :data_source_uuid
 
-    include API::Actions::All
     include API::Actions::Create
     include API::Actions::Update
     include API::Actions::Destroy
@@ -22,5 +20,22 @@ module ChartMogul
     def self.retrieve(uuid)
       custom!(:get, "/v1/plans/#{uuid}")
     end
+
+    def self.all(options = {})
+      Plans.all(options)
+    end
+  end
+
+
+  class Plans < APIResource
+    set_resource_name 'Plans'
+    set_resource_path '/v1/plans'
+
+    set_resource_root_key :plans
+
+    include Concerns::Entries
+    include Concerns::Pageable2
+
+    set_entry_class Plan
   end
 end

--- a/lib/chartmogul/subscription.rb
+++ b/lib/chartmogul/subscription.rb
@@ -23,7 +23,7 @@ module ChartMogul
     end
 
     def self.all(customer_uuid, options = {})
-      Subscriptions.all(options.merge(customer_uuid: customer_uuid))
+      Subscriptions.all(customer_uuid, options)
     end
   end
 
@@ -39,6 +39,10 @@ module ChartMogul
     include Concerns::Pageable2
 
     set_entry_class Subscription
+
+    def self.all(customer_uuid, options = {})
+      super(options.merge(customer_uuid: customer_uuid))
+    end
 
   end
 end

--- a/lib/chartmogul/subscription.rb
+++ b/lib/chartmogul/subscription.rb
@@ -2,7 +2,6 @@ module ChartMogul
   class Subscription < APIResource
     set_resource_name 'Subscription'
     set_resource_path '/v1/import/customers/:customer_uuid/subscriptions'
-    set_resource_root_key :subscriptions
 
     readonly_attr :uuid
     readonly_attr :external_id
@@ -11,7 +10,6 @@ module ChartMogul
     readonly_attr :plan_uuid
     readonly_attr :data_source_uuid
 
-    include API::Actions::All
     include API::Actions::Custom
 
     def set_cancellation_dates(cancellation_dates_array)
@@ -25,7 +23,22 @@ module ChartMogul
     end
 
     def self.all(customer_uuid, options = {})
-      super(options.merge(customer_uuid: customer_uuid))
+      Subscriptions.all(options.merge(customer_uuid: customer_uuid))
     end
+  end
+
+  class Subscriptions < APIResource
+    readonly_attr :customer_uuid
+
+    set_resource_name 'Subscriptions'
+    set_resource_path '/v1/import/customers/:customer_uuid/subscriptions'
+
+    set_resource_root_key :subscriptions
+
+    include Concerns::Entries
+    include Concerns::Pageable2
+
+    set_entry_class Subscription
+
   end
 end

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,3 +1,3 @@
 module ChartMogul
-  VERSION = "1.0.2"
+  VERSION = "1.1.0"
 end

--- a/spec/chartmogul/customer_spec.rb
+++ b/spec/chartmogul/customer_spec.rb
@@ -137,7 +137,11 @@ describe ChartMogul::Customer do
       )
 
       customers = ChartMogul::Customer.all
-
+      expect(customers.current_page).to eq(1)
+      expect(customers.total_pages).to eq(1)
+      expect(customers.page).to eq(1)
+      expect(customers.per_page).to eq(50)
+      expect(customers.has_more).to eq(false)
       expect(customers.size).to eq(1)
       expect(customers[0].uuid).not_to be_nil
       expect(customers[0].name).to eq('Test Customer')

--- a/spec/chartmogul/customer_spec.rb
+++ b/spec/chartmogul/customer_spec.rb
@@ -176,6 +176,14 @@ describe ChartMogul::Customer do
       expect(customers.page).to eq(1)
     end
 
+    it 'can page through search endpoint', uses_api: true do
+      customers = described_class.search('adam@smith.com', {page: 2, per_page: 1})
+      expect(customers.first.email).to eq('adam@smith.com')
+      expect(customers.has_more).to eq(false)
+      expect(customers.per_page).to eq(1)
+      expect(customers.page).to eq(2)
+    end
+
     it 'raises 404 if no customers found', uses_api: true do
       expect{described_class.search('no@email.com')}.to raise_error(ChartMogul::NotFoundError)
     end

--- a/spec/chartmogul/subscription_spec.rb
+++ b/spec/chartmogul/subscription_spec.rb
@@ -38,6 +38,14 @@ describe ChartMogul::Subscription do
         invoices: [invoice]
       ).create!
 
+
+      expect(customer.subscriptions.current_page).to eq(1)
+      expect(customer.subscriptions.total_pages).to eq(1)
+      expect(customer.subscriptions.size).to eq(1)
+      expect(customer.subscriptions.first.uuid).to eq("sub_9b3ccf25-4613-4af6-84b3-12026cfa4b7c")
+      expect(customer.subscriptions.first.data_source_uuid).to eq("ds_55ab11fb-53e6-4468-aa95-bd582f14cac6")
+      expect(customer.subscriptions.first.external_id).to eq("test_cus_sub_ext_id")
+
       customer.subscriptions.first.cancel(Time.utc(2016, 1, 15, 12))
 
       expect(customer.subscriptions.first.cancellation_dates).to match_array(

--- a/spec/chartmogul/subscription_spec.rb
+++ b/spec/chartmogul/subscription_spec.rb
@@ -54,5 +54,19 @@ describe ChartMogul::Subscription do
 
       data_source.destroy!
     end
+
+    it 'has multiple aliases', uses_api: true do
+      subscriptions = described_class.all("cus_510b1395-4fe8-4d35-ae23-0e61f9a51e33", {page: 1, per_page: 2})
+      expect(subscriptions.current_page).to eq(1)
+      expect(subscriptions.total_pages).to eq(1)
+      expect(subscriptions.size).to eq(1)
+      expect(subscriptions.first.uuid).to eq("sub_9b3ccf25-4613-4af6-84b3-12026cfa4b7c")
+
+      subscriptions = ChartMogul::Subscriptions.all("cus_510b1395-4fe8-4d35-ae23-0e61f9a51e33", {page: 2, per_page: 1})
+      expect(subscriptions.current_page).to eq(2)
+      expect(subscriptions.total_pages).to eq(2)
+      expect(subscriptions.size).to eq(1)
+      expect(subscriptions.first.uuid).to eq("sub_9b3ccf25-4613-4af6-84b3-12026cfa4b7c")
+    end
   end
 end


### PR DESCRIPTION
* entries mapping mechanism was on 3 places, reduced to 1
* now only in `Entries` concern, which now honors both `root_key` and `entry_class`
* `Customers.search` couldn't take paging params
* plural.all and singular.all aliases, tested
* version to 1.1.0
* backwards compatible (thanks to delegators the Classes look like arrays)