### PR TITLE
[DP-309] support for Delete Invoice

### DIFF
--- a/fixtures/vcr_cassettes/ChartMogul_Invoice/API_Interactions/deletes_an_invoice.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Invoice/API_Interactions/deletes_an_invoice.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.chartmogul.com/v1/invoices/inv_123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+  response:
+    status:
+      code: 204
+      message: No content
+    headers:
+      server:
+      - nginx/1.9.10
+      date:
+      - Wed, 29 Jun 2016 12:45:27 GMT
+      content-length:
+      - '0'
+      connection:
+      - close
+      vary:
+      - Accept-Encoding
+      status:
+      - 204 No content
+      access-control-allow-credentials:
+      - 'true'
+    http_version:
+  recorded_at: Wed, 29 Jun 2016 12:45:27 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/ChartMogul_Invoice/API_Interactions/deletes_an_invoice_with_class_method.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Invoice/API_Interactions/deletes_an_invoice_with_class_method.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.chartmogul.com/v1/invoices/inv_12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+  response:
+    status:
+      code: 204
+      message: No content
+    headers:
+      server:
+      - nginx/1.9.10
+      date:
+      - Wed, 29 Jun 2016 12:45:27 GMT
+      content-length:
+      - '0'
+      connection:
+      - close
+      vary:
+      - Accept-Encoding
+      status:
+      - 204 No content
+      access-control-allow-credentials:
+      - 'true'
+    http_version:
+  recorded_at: Wed, 29 Jun 2016 12:45:27 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/ChartMogul_Invoice/API_Interactions/raises_error_on_deleting_non-existing_invoice.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Invoice/API_Interactions/raises_error_on_deleting_non-existing_invoice.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.chartmogul.com/v1/invoices/inv_123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+  response:
+    status:
+      code: 404
+      message: Not found
+    headers:
+      server:
+      - nginx/1.9.10
+      date:
+      - Wed, 29 Jun 2016 12:45:27 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '35'
+      connection:
+      - close
+      vary:
+      - Accept-Encoding
+      status:
+      - 404 Not found
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"error":"Invoice not found"}'
+    http_version:
+  recorded_at: Wed, 29 Jun 2016 12:45:27 GMT
+recorded_with: VCR 3.0.3

--- a/lib/chartmogul/api/actions/destroy.rb
+++ b/lib/chartmogul/api/actions/destroy.rb
@@ -1,12 +1,26 @@
+require 'pp'
 module ChartMogul
   module API
     module Actions
       module Destroy
+        def self.included(base)
+          base.extend ClassMethods
+        end
+
         def destroy!
           handling_errors do
             connection.delete("#{resource_path.apply(self.instance_attributes)}/#{uuid}")
           end
           true
+        end
+
+        module ClassMethods
+          def destroy!(options = {})
+            handling_errors do
+              connection.delete("#{resource_path.apply(options)}/#{options[:uuid]}")
+            end
+            true
+          end
         end
       end
     end

--- a/lib/chartmogul/invoice.rb
+++ b/lib/chartmogul/invoice.rb
@@ -1,5 +1,8 @@
 module ChartMogul
-  class Invoice < ChartMogul::Object
+  class Invoice < APIResource
+    set_resource_name 'Invoice'
+    set_resource_path '/v1/invoices'
+
     readonly_attr :uuid
     readonly_attr :customer_uuid
 
@@ -9,6 +12,8 @@ module ChartMogul
     writeable_attr :transactions, default: []
     writeable_attr :external_id
     writeable_attr :due_date, type: :time
+
+    include API::Actions::Destroy
 
     def serialize_line_items
       line_items.map(&:serialize_for_write)

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,3 +1,3 @@
 module ChartMogul
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end

--- a/spec/chartmogul/invoice_spec.rb
+++ b/spec/chartmogul/invoice_spec.rb
@@ -234,5 +234,17 @@ describe ChartMogul::Invoice do
       expect(invoices[0].external_id).to eq "invoice_eid"
       expect(invoices[0].customer_uuid).to eq "customer_uuid"
     end
+
+    it 'deletes an invoice', uses_api: true do
+      invoice = described_class.new
+      invoice.instance_variable_set(:@uuid, 'inv_123') # hack-write private uuid
+      invoice.destroy! # expect no exception :)
+    end
+
+    it 'raises error on deleting non-existing invoice', uses_api: true do
+      invoice = described_class.new
+      invoice.instance_variable_set(:@uuid, 'inv_I_dont_exists') # hack-write private uuid
+      expect{invoice.destroy!}.to raise_error(ChartMogul::ChartMogulError)
+    end
   end
 end

--- a/spec/chartmogul/invoice_spec.rb
+++ b/spec/chartmogul/invoice_spec.rb
@@ -240,6 +240,9 @@ describe ChartMogul::Invoice do
       invoice.instance_variable_set(:@uuid, 'inv_123') # hack-write private uuid
       invoice.destroy! # expect no exception :)
     end
+    it 'deletes an invoice with class method', uses_api: true do
+      ChartMogul::Invoice.destroy!(uuid: 'inv_12345')
+    end
 
     it 'raises error on deleting non-existing invoice', uses_api: true do
       invoice = described_class.new


### PR DESCRIPTION
* the same as other resources
* because user couldn't do `Invoice.destroy!(uuid)`, and instead they had to first retrieve the invoice, I've added static method `resource.destroy!(uuid: 'uuid')`, which applies also to customers, plans & data sources