### PR TITLE
Rubocop autocorrect, bump version to 1.1.5

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
-require "chartmogul"
+require 'bundler/setup'
+require 'chartmogul'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +10,5 @@ require "chartmogul"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start

--- a/chartmogul-ruby.gemspec
+++ b/chartmogul-ruby.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'chartmogul/version'

--- a/lib/chartmogul.rb
+++ b/lib/chartmogul.rb
@@ -2,71 +2,71 @@ require 'time'
 require 'json'
 require 'faraday'
 
-require "chartmogul/version"
+require 'chartmogul/version'
 
-require "chartmogul/utils/hash_snake_caser"
-require "chartmogul/utils/json_parser"
+require 'chartmogul/utils/hash_snake_caser'
+require 'chartmogul/utils/json_parser'
 
-require "chartmogul/errors/chartmogul_error"
-require "chartmogul/errors/configuration_error"
-require "chartmogul/errors/not_found_error"
-require "chartmogul/errors/resource_invalid_error"
-require "chartmogul/errors/schema_invalid_error"
-require "chartmogul/errors/unauthorized_error"
-require "chartmogul/errors/forbidden_error"
+require 'chartmogul/errors/chartmogul_error'
+require 'chartmogul/errors/configuration_error'
+require 'chartmogul/errors/forbidden_error'
+require 'chartmogul/errors/not_found_error'
+require 'chartmogul/errors/resource_invalid_error'
+require 'chartmogul/errors/schema_invalid_error'
+require 'chartmogul/errors/unauthorized_error'
 
-require "chartmogul/config_attributes"
-require "chartmogul/configuration"
+require 'chartmogul/config_attributes'
+require 'chartmogul/configuration'
 
-require "chartmogul/object"
-require "chartmogul/resource_path"
-require "chartmogul/api_resource"
-require "chartmogul/summary"
+require 'chartmogul/object'
+require 'chartmogul/resource_path'
+require 'chartmogul/api_resource'
+require 'chartmogul/summary'
 
-require "chartmogul/api/actions/all"
-require "chartmogul/api/actions/create"
-require "chartmogul/api/actions/custom"
-require "chartmogul/api/actions/destroy"
-require "chartmogul/api/actions/retrieve"
-require "chartmogul/api/actions/update"
+require 'chartmogul/api/actions/all'
+require 'chartmogul/api/actions/create'
+require 'chartmogul/api/actions/custom'
+require 'chartmogul/api/actions/destroy'
+require 'chartmogul/api/actions/retrieve'
+require 'chartmogul/api/actions/update'
 
-require "chartmogul/line_items/one_time"
-require "chartmogul/line_items/subscription"
+require 'chartmogul/line_items/one_time'
+require 'chartmogul/line_items/subscription'
 
-require "chartmogul/transactions/payment"
-require "chartmogul/transactions/refund"
+require 'chartmogul/transactions/payment'
+require 'chartmogul/transactions/refund'
 
-require "chartmogul/concerns/entries"
-require "chartmogul/concerns/summary"
-require "chartmogul/concerns/pageable"
-require "chartmogul/concerns/pageable2"
+require 'chartmogul/concerns/entries'
+require 'chartmogul/concerns/summary'
+require 'chartmogul/concerns/pageable'
+require 'chartmogul/concerns/pageable2'
 
-require "chartmogul/subscription"
-require "chartmogul/invoice"
-require "chartmogul/customer_invoices"
-require "chartmogul/customer"
-require "chartmogul/data_source"
-require "chartmogul/ping"
-require "chartmogul/plan"
+require 'chartmogul/subscription'
+require 'chartmogul/invoice'
+require 'chartmogul/customer_invoices'
+require 'chartmogul/customer'
+require 'chartmogul/data_source'
+require 'chartmogul/ping'
+require 'chartmogul/plan'
 
-require "chartmogul/metrics/arpa"
-require "chartmogul/metrics/arr"
-require "chartmogul/metrics/asp"
-require "chartmogul/metrics/customer_churn_rate"
-require "chartmogul/metrics/customer_count"
-require "chartmogul/metrics/ltv"
-require "chartmogul/metrics/mrr"
-require "chartmogul/metrics/mrr_churn_rate"
-require "chartmogul/metrics/all_key_metrics"
-require "chartmogul/metrics/base"
+require 'chartmogul/metrics/arpa'
+require 'chartmogul/metrics/arr'
+require 'chartmogul/metrics/asp'
+require 'chartmogul/metrics/customer_churn_rate'
+require 'chartmogul/metrics/customer_count'
+require 'chartmogul/metrics/ltv'
+require 'chartmogul/metrics/mrr'
+require 'chartmogul/metrics/mrr_churn_rate'
+require 'chartmogul/metrics/all_key_metrics'
+require 'chartmogul/metrics/base'
 
-require "chartmogul/metrics/activity"
-require "chartmogul/metrics/subscription"
+require 'chartmogul/metrics/activity'
+require 'chartmogul/metrics/subscription'
 
-require "chartmogul/enrichment/customer"
+require 'chartmogul/enrichment/customer'
 
 module ChartMogul
-  API_BASE = 'https://api.chartmogul.com'
+  API_BASE = 'https://api.chartmogul.com'.freeze
 
   class << self
     extend ConfigAttributes

--- a/lib/chartmogul/api/actions/create.rb
+++ b/lib/chartmogul/api/actions/create.rb
@@ -8,9 +8,9 @@ module ChartMogul
 
         def create!
           resp = handling_errors do
-            connection.post(resource_path.apply(self.instance_attributes)) do |req|
+            connection.post(resource_path.apply(instance_attributes)) do |req|
               req.headers['Content-Type'] = 'application/json'
-              req.body = JSON.dump(self.serialize_for_write)
+              req.body = JSON.dump(serialize_for_write)
             end
           end
           json = ChartMogul::Utils::JSONParser.parse(resp.body)

--- a/lib/chartmogul/api/actions/destroy.rb
+++ b/lib/chartmogul/api/actions/destroy.rb
@@ -8,7 +8,7 @@ module ChartMogul
 
         def destroy!
           handling_errors do
-            connection.delete("#{resource_path.apply(self.instance_attributes)}/#{uuid}")
+            connection.delete("#{resource_path.apply(instance_attributes)}/#{uuid}")
           end
           true
         end

--- a/lib/chartmogul/api/actions/update.rb
+++ b/lib/chartmogul/api/actions/update.rb
@@ -4,9 +4,9 @@ module ChartMogul
       module Update
         def update!
           resp = handling_errors do
-            connection.patch("#{resource_path.apply(self.instance_attributes)}/#{uuid}") do |req|
+            connection.patch("#{resource_path.apply(instance_attributes)}/#{uuid}") do |req|
               req.headers['Content-Type'] = 'application/json'
-              req.body = JSON.dump(self.serialize_for_write)
+              req.body = JSON.dump(serialize_for_write)
             end
           end
           json = ChartMogul::Utils::JSONParser.parse(resp.body)

--- a/lib/chartmogul/api_resource.rb
+++ b/lib/chartmogul/api_resource.rb
@@ -17,7 +17,7 @@ module ChartMogul
     def self.set_resource_root_key(root_key)
       @resource_root_key = root_key
     end
-    
+
     def self.connection
       @connection ||= Faraday.new(url: ChartMogul::API_BASE) do |faraday|
         faraday.use Faraday::Request::BasicAuthentication, ChartMogul.account_token, ChartMogul.secret_key
@@ -45,7 +45,7 @@ module ChartMogul
         message = 'No valid API key provided'
         raise ChartMogul::UnauthorizedError.new(message, http_status: 401, response: response)
       when 403
-        message = "The requested action is forbidden."
+        message = 'The requested action is forbidden.'
         raise ChartMogul::ForbiddenError.new(message, http_status: 403, response: response)
       when 404
         message = "The requested #{resource_name} could not be found."
@@ -60,7 +60,7 @@ module ChartMogul
     end
 
     def self.handle_other_error(exception)
-      raise ChartMogul::ChartMogulError.new(exception.message)
+      raise ChartMogul::ChartMogulError, exception.message
     end
 
     def_delegators 'self.class', :resource_path, :resource_name, :resource_root_key, :connection, :handling_errors

--- a/lib/chartmogul/concerns/entries.rb
+++ b/lib/chartmogul/concerns/entries.rb
@@ -5,9 +5,7 @@ module ChartMogul
         base.extend ClassMethods
 
         base.instance_eval do
-          if @resource_root_key.nil?
-            @resource_root_key = :entries
-          end
+          @resource_root_key = :entries if @resource_root_key.nil?
           readonly_attr @resource_root_key, default: []
 
           include API::Actions::All
@@ -16,22 +14,22 @@ module ChartMogul
           def_delegators @resource_root_key, :each, :[], :<<, :size, :length, :empty?, :first
 
           resource_root_key = @resource_root_key.to_s
-          base.send :define_method, "set_" + resource_root_key do |entries|
+          base.send :define_method, 'set_' + resource_root_key do |entries|
             objects = entries.map do |entity|
               self.class.get_entry_class.new_from_json(entity)
             end
-            self.instance_variable_set "@#{resource_root_key}", objects
+            instance_variable_set "@#{resource_root_key}", objects
           end
         end
       end
 
       module ClassMethods
         def set_entry_class(klass)
-          instance_variable_set("@entry_class", klass)
+          instance_variable_set('@entry_class', klass)
         end
 
         def get_entry_class
-          instance_variable_get("@entry_class")
+          instance_variable_get('@entry_class')
         end
       end
     end

--- a/lib/chartmogul/concerns/summary.rb
+++ b/lib/chartmogul/concerns/summary.rb
@@ -17,4 +17,3 @@ module ChartMogul
     end
   end
 end
-

--- a/lib/chartmogul/config_attributes.rb
+++ b/lib/chartmogul/config_attributes.rb
@@ -3,7 +3,7 @@ module ChartMogul
     def config_accessor(attribute)
       define_method(attribute) do
         attr = config.send(attribute)
-        raise ConfigurationError.new("Configuration for #{attribute} not set") if attr.nil?
+        raise ConfigurationError, "Configuration for #{attribute} not set" if attr.nil?
         attr
       end
 

--- a/lib/chartmogul/customer.rb
+++ b/lib/chartmogul/customer.rb
@@ -42,7 +42,6 @@ module ChartMogul
       Customers.all(options)
     end
 
-
     def self.search(email, options = {})
       Customers.search(email, options)
     end
@@ -129,7 +128,11 @@ module ChartMogul
     def typecast_custom_attributes(custom_attributes)
       return {} unless custom_attributes
       custom_attributes.each_with_object({}) do |(key, value), hash|
-        hash[key] = value.instance_of?(String) ? (Time.parse(value) rescue value) : value
+        hash[key] = value.instance_of?(String) ? (begin
+                                                    Time.parse(value)
+                                                  rescue
+                                                    value
+                                                  end) : value
       end
     end
   end

--- a/lib/chartmogul/data_source.rb
+++ b/lib/chartmogul/data_source.rb
@@ -21,7 +21,6 @@ module ChartMogul
     end
   end
 
-
   class DataSources < APIResource
     set_resource_name 'Data Sources'
     set_resource_path '/v1/data_sources'

--- a/lib/chartmogul/enrichment/customer.rb
+++ b/lib/chartmogul/enrichment/customer.rb
@@ -1,9 +1,7 @@
 module ChartMogul
   module Enrichment
-
     # <b>DEPRECATED:</b> Please use <tt>ChartMogul/Customer</tt> instead.
     class DeprecatedCustomer < APIResource
-
       set_resource_name 'Customer'
       set_resource_path '/v1/customers'
 
@@ -108,14 +106,18 @@ module ChartMogul
       def typecast_custom_attributes(custom_attributes)
         return {} unless custom_attributes
         custom_attributes.each_with_object({}) do |(key, value), hash|
-          hash[key] = value.instance_of?(String) ? (Time.parse(value) rescue value) : value
+          hash[key] = value.instance_of?(String) ? (begin
+                                                      Time.parse(value)
+                                                    rescue
+                                                      value
+                                                    end) : value
         end
       end
     end
 
     def self.const_missing(const_name)
       super unless const_name == :Customer
-      warn "DEPRECATION WARNING: the class ChartMogul::Enrichment::Customer is deprecated. Use ChartMogul::Customer instead."
+      warn 'DEPRECATION WARNING: the class ChartMogul::Enrichment::Customer is deprecated. Use ChartMogul::Customer instead.'
       DeprecatedCustomer
     end
 

--- a/lib/chartmogul/errors/chartmogul_error.rb
+++ b/lib/chartmogul/errors/chartmogul_error.rb
@@ -4,15 +4,15 @@ module ChartMogul
     attr_accessor :response
     attr_accessor :http_status
 
-    def initialize(message, http_status:nil, response:nil)
+    def initialize(message, http_status: nil, response: nil)
       @message = message
       @http_status = http_status
       @response = response
     end
 
     def to_s
-      status = @http_status ? " (HTTP Status: #{@http_status.to_s})" : ''
-      response = @response ? "\nResponse: #{@response.to_s}" : ''
+      status = @http_status ? " (HTTP Status: #{@http_status})" : ''
+      response = @response ? "\nResponse: #{@response}" : ''
       "#{message}#{status}#{response}"
     end
   end

--- a/lib/chartmogul/metrics/activity.rb
+++ b/lib/chartmogul/metrics/activity.rb
@@ -31,4 +31,3 @@ module ChartMogul
     end
   end
 end
-

--- a/lib/chartmogul/metrics/all_key_metrics.rb
+++ b/lib/chartmogul/metrics/all_key_metrics.rb
@@ -22,4 +22,3 @@ module ChartMogul
     end
   end
 end
-

--- a/lib/chartmogul/metrics/arpa.rb
+++ b/lib/chartmogul/metrics/arpa.rb
@@ -16,4 +16,3 @@ module ChartMogul
     end
   end
 end
-

--- a/lib/chartmogul/metrics/arr.rb
+++ b/lib/chartmogul/metrics/arr.rb
@@ -16,4 +16,3 @@ module ChartMogul
     end
   end
 end
-

--- a/lib/chartmogul/metrics/asp.rb
+++ b/lib/chartmogul/metrics/asp.rb
@@ -16,4 +16,3 @@ module ChartMogul
     end
   end
 end
-

--- a/lib/chartmogul/metrics/base.rb
+++ b/lib/chartmogul/metrics/base.rb
@@ -1,6 +1,5 @@
 module ChartMogul
   module Metrics
-
     def self.all(options = {})
       ChartMogul::Metrics::AllKeyMetrics.all(preprocess_params(options))
     end
@@ -40,12 +39,12 @@ module ChartMogul
     private
 
     def self.preprocess_params(options)
-      [:start_date, :end_date].each do |param_name|
-        options[param_name.to_s.gsub('_', '-')] = options.delete(param_name) if options[param_name]
+      %i[start_date end_date].each do |param_name|
+        options[param_name.to_s.tr('_', '-')] = options.delete(param_name) if options[param_name]
       end
 
-      [:geo, :plans].each do |param_name|
-        if options[param_name] && options[param_name].kind_of?(Array)
+      %i[geo plans].each do |param_name|
+        if options[param_name] && options[param_name].is_a?(Array)
           options[param_name] = options[param_name].join(',')
         end
       end
@@ -53,4 +52,3 @@ module ChartMogul
     end
   end
 end
-

--- a/lib/chartmogul/metrics/customer_churn_rate.rb
+++ b/lib/chartmogul/metrics/customer_churn_rate.rb
@@ -16,4 +16,3 @@ module ChartMogul
     end
   end
 end
-

--- a/lib/chartmogul/metrics/customer_count.rb
+++ b/lib/chartmogul/metrics/customer_count.rb
@@ -16,4 +16,3 @@ module ChartMogul
     end
   end
 end
-

--- a/lib/chartmogul/metrics/ltv.rb
+++ b/lib/chartmogul/metrics/ltv.rb
@@ -16,4 +16,3 @@ module ChartMogul
     end
   end
 end
-

--- a/lib/chartmogul/metrics/mrr_churn_rate.rb
+++ b/lib/chartmogul/metrics/mrr_churn_rate.rb
@@ -16,4 +16,3 @@ module ChartMogul
     end
   end
 end
-

--- a/lib/chartmogul/object.rb
+++ b/lib/chartmogul/object.rb
@@ -64,8 +64,8 @@ module ChartMogul
       assign_writeable_attributes(attributes)
     end
 
-    def self.new_from_json(attributes={})
-      self.new.tap do |resource|
+    def self.new_from_json(attributes = {})
+      new.tap do |resource|
         resource.assign_all_attributes(attributes)
       end
     end
@@ -77,8 +77,8 @@ module ChartMogul
     end
 
     def assign_writeable_attributes(new_values)
-      self.class.writeable_attributes.each do |attr, value|
-        self.send("#{attr}=", new_values[attr]) if new_values.key?(attr)
+      self.class.writeable_attributes.each do |attr, _value|
+        send("#{attr}=", new_values[attr]) if new_values.key?(attr)
       end
 
       self
@@ -86,7 +86,7 @@ module ChartMogul
 
     def assign_all_attributes(new_values)
       self.class.attributes.each do |attr|
-        self.send("set_#{attr}", new_values[attr]) if new_values.key?(attr)
+        send("set_#{attr}", new_values[attr]) if new_values.key?(attr)
       end
 
       self

--- a/lib/chartmogul/ping.rb
+++ b/lib/chartmogul/ping.rb
@@ -7,7 +7,7 @@ module ChartMogul
 
     include API::Actions::Custom
 
-    def self.ping()
+    def self.ping
       custom!(:get, '/v1/ping')
     end
   end

--- a/lib/chartmogul/plan.rb
+++ b/lib/chartmogul/plan.rb
@@ -23,7 +23,6 @@ module ChartMogul
     end
   end
 
-
   class Plans < APIResource
     set_resource_name 'Plans'
     set_resource_path '/v1/plans'

--- a/lib/chartmogul/resource_path.rb
+++ b/lib/chartmogul/resource_path.rb
@@ -10,7 +10,7 @@ module ChartMogul
     def initialize(path)
       @path = path
       @named_params = path.scan(/:\w+/).each_with_object({}) do |named_param, hash|
-        hash[named_param] = named_param.gsub(':', '').to_sym
+        hash[named_param] = named_param.delete(':').to_sym
       end
     end
 

--- a/lib/chartmogul/subscription.rb
+++ b/lib/chartmogul/subscription.rb
@@ -43,6 +43,5 @@ module ChartMogul
     def self.all(customer_uuid, options = {})
       super(options.merge(customer_uuid: customer_uuid))
     end
-
   end
 end

--- a/lib/chartmogul/utils/hash_snake_caser.rb
+++ b/lib/chartmogul/utils/hash_snake_caser.rb
@@ -39,12 +39,11 @@ module ChartMogul
 
       def underscore(string)
         string.gsub(/::/, '/')
-          .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
-          .gsub(/([a-z\d])([A-Z])/, '\1_\2')
-          .tr('-', '_')
-          .downcase
+              .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+              .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+              .tr('-', '_')
+              .downcase
       end
     end
   end
 end
-

--- a/lib/chartmogul/utils/json_parser.rb
+++ b/lib/chartmogul/utils/json_parser.rb
@@ -8,4 +8,3 @@ module ChartMogul
     end
   end
 end
-

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,3 +1,3 @@
 module ChartMogul
-  VERSION = "1.1.4"
+  VERSION = '1.1.5'.freeze
 end

--- a/spec/chartmogul/configuration_spec.rb
+++ b/spec/chartmogul/configuration_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe 'ChartMogul configuration' do
   describe 'account_token' do
     it 'sets the configuration' do
-      ChartMogul.account_token = "abcdef1234567890"
-      expect(ChartMogul.account_token).to eq("abcdef1234567890")
+      ChartMogul.account_token = 'abcdef1234567890'
+      expect(ChartMogul.account_token).to eq('abcdef1234567890')
     end
 
     it 'raises a ChartMogul::ConfigurationError when not set' do
@@ -15,8 +15,8 @@ describe 'ChartMogul configuration' do
 
   describe 'secret_key' do
     it 'sets the configuration' do
-      ChartMogul.secret_key = "abcdef1234567890"
-      expect(ChartMogul.secret_key).to eq("abcdef1234567890")
+      ChartMogul.secret_key = 'abcdef1234567890'
+      expect(ChartMogul.secret_key).to eq('abcdef1234567890')
     end
 
     it 'raises a ChartMogul::ConfigurationError when not set' do

--- a/spec/chartmogul/customer_invoices_spec.rb
+++ b/spec/chartmogul/customer_invoices_spec.rb
@@ -81,7 +81,7 @@ describe ChartMogul::CustomerInvoices do
               discount_amount_in_cents: 1200,
               discount_code: 'DISCCODE',
               tax_amount_in_cents: 200,
-              external_id: 'one_time_ext_id',
+              external_id: 'one_time_ext_id'
             ),
             ChartMogul::LineItems::OneTime.new(
               amount_in_cents: 1000,
@@ -90,23 +90,23 @@ describe ChartMogul::CustomerInvoices do
               discount_amount_in_cents: 1200,
               discount_code: 'DISCCODE',
               tax_amount_in_cents: 200,
-              external_id: 'one_time_ext_id',
+              external_id: 'one_time_ext_id'
             )
           ],
           transactions: [
             ChartMogul::Transactions::Payment.new(
               date: '2016-01-01 12:00:00',
               result: 'successful',
-              external_id: 'pay_ext_id',
+              external_id: 'pay_ext_id'
             ),
             ChartMogul::Transactions::Refund.new(
               date: '2016-01-01 12:00:00',
               result: 'successful',
-              external_id: 'ref_ext_id',
+              external_id: 'ref_ext_id'
             )
           ],
           external_id: 'inv_ext_id',
-          due_date: '2016-02-01 12:00:00',
+          due_date: '2016-02-01 12:00:00'
         )
       ],
       customer_uuid: 'cus_1234-5678-9012-34567'
@@ -227,12 +227,12 @@ describe ChartMogul::CustomerInvoices do
         discount_amount_in_cents: 1200,
         discount_code: 'DISCCODE',
         tax_amount_in_cents: 200,
-        external_id: 'test_cus_li_ext_id',
+        external_id: 'test_cus_li_ext_id'
       )
       transaction = ChartMogul::Transactions::Payment.new(
         date: Time.utc(2016, 1, 1, 12),
         result: 'successful',
-        external_id: 'test_cus_tr_ext_id',
+        external_id: 'test_cus_tr_ext_id'
       )
       invoice = ChartMogul::Invoice.new(
         date: Time.utc(2016, 1, 1, 12),

--- a/spec/chartmogul/customer_spec.rb
+++ b/spec/chartmogul/customer_spec.rb
@@ -11,8 +11,8 @@ describe ChartMogul::Customer do
       state: 'BE',
       country: 'DE',
       zip: '10115',
-      lead_created_at: Time.utc(2016,10,1).to_s,
-      free_trial_started_at: Time.utc(2016,10,2).to_s
+      lead_created_at: Time.utc(2016, 10, 1).to_s,
+      free_trial_started_at: Time.utc(2016, 10, 2).to_s
     }
   end
 
@@ -51,11 +51,11 @@ describe ChartMogul::Customer do
     end
 
     it 'sets the lead_created_at attribute' do
-      expect(subject.lead_created_at).to eq(Time.utc(2016,10,1).to_s)
+      expect(subject.lead_created_at).to eq(Time.utc(2016, 10, 1).to_s)
     end
 
     it 'sets the free_trial_started_at attribute' do
-      expect(subject.free_trial_started_at).to eq(Time.utc(2016,10,2).to_s)
+      expect(subject.free_trial_started_at).to eq(Time.utc(2016, 10, 2).to_s)
     end
   end
 
@@ -95,11 +95,11 @@ describe ChartMogul::Customer do
     end
 
     it 'sets the lead_created_at attribute' do
-      expect(subject.lead_created_at).to eq(Time.utc(2016,10,1))
+      expect(subject.lead_created_at).to eq(Time.utc(2016, 10, 1))
     end
 
     it 'sets the free_trial_started_at attribute' do
-      expect(subject.free_trial_started_at).to eq(Time.utc(2016,10,2))
+      expect(subject.free_trial_started_at).to eq(Time.utc(2016, 10, 2))
     end
   end
 
@@ -119,8 +119,8 @@ describe ChartMogul::Customer do
   end
 
   describe 'API Interactions', vcr: true do
-    let(:lead_created_at) { Time.utc(2016,10,1,23,55) }
-    let(:free_trial_started_at) { Time.utc(2016,10,12,11,12) }
+    let(:lead_created_at) { Time.utc(2016, 10, 1, 23, 55) }
+    let(:free_trial_started_at) { Time.utc(2016, 10, 12, 11, 12) }
 
     it 'correctly interracts with the API', uses_api: true do
       ds = ChartMogul::DataSource.create!(name: 'Customer Test Data Source')
@@ -177,7 +177,7 @@ describe ChartMogul::Customer do
     end
 
     it 'can page through search endpoint', uses_api: true do
-      customers = described_class.search('adam@smith.com', {page: 2, per_page: 1})
+      customers = described_class.search('adam@smith.com', page: 2, per_page: 1)
       expect(customers.first.email).to eq('adam@smith.com')
       expect(customers.has_more).to eq(false)
       expect(customers.per_page).to eq(1)
@@ -185,7 +185,7 @@ describe ChartMogul::Customer do
     end
 
     it 'raises 404 if no customers found', uses_api: true do
-      expect{described_class.search('no@email.com')}.to raise_error(ChartMogul::NotFoundError)
+      expect { described_class.search('no@email.com') }.to raise_error(ChartMogul::NotFoundError)
     end
 
     it 'returns customer through retrieve endpoint', uses_api: true do
@@ -208,15 +208,15 @@ describe ChartMogul::Customer do
     it 'adds custom attributes', uses_api: true do
       customer = described_class.retrieve('cus_07393ece-aab1-4255-8bcd-0ef11e24b047')
       customer.add_custom_attributes!(
-        { type: "String", key: "string_key", value: "String Value" },
-        { type: "Integer", key: "integer_key", value: 1234 },
-        { type: "Timestamp", key: "timestamp_key", value: Time.utc(2016,01,31) },
-        { type: "Boolean", key: "boolean_key", value: true }
+        { type: 'String', key: 'string_key', value: 'String Value' },
+        { type: 'Integer', key: 'integer_key', value: 1234 },
+        { type: 'Timestamp', key: 'timestamp_key', value: Time.utc(2016, 0o1, 31) },
+        type: 'Boolean', key: 'boolean_key', value: true
       )
       expect(customer.custom_attributes).to eq(
-        string_key: "String Value",
+        string_key: 'String Value',
         integer_key: 1234,
-        timestamp_key: Time.utc(2016,01,31),
+        timestamp_key: Time.utc(2016, 0o1, 31),
         boolean_key: true
       )
     end
@@ -224,15 +224,15 @@ describe ChartMogul::Customer do
     it 'updates custom attributes', uses_api: true do
       customer = described_class.retrieve('cus_07393ece-aab1-4255-8bcd-0ef11e24b047')
       customer.update_custom_attributes!(
-        string_key: "Another String Value",
+        string_key: 'Another String Value',
         integer_key: 5678,
-        timestamp_key: Time.utc(2016,02,1),
+        timestamp_key: Time.utc(2016, 0o2, 1),
         boolean_key: false
       )
       expect(customer.custom_attributes).to eq(
-        string_key: "Another String Value",
+        string_key: 'Another String Value',
         integer_key: 5678,
-        timestamp_key: Time.utc(2016,02,1),
+        timestamp_key: Time.utc(2016, 0o2, 1),
         boolean_key: false
       )
     end
@@ -270,8 +270,8 @@ describe ChartMogul::Customer do
       customer.country = 'DE'
       customer.state = 'NY'
       customer.city = 'Berlin'
-      customer.lead_created_at = Time.utc(2016,1,1,14,30)
-      customer.free_trial_started_at = Time.utc(2016,2,2,22,40)
+      customer.lead_created_at = Time.utc(2016, 1, 1, 14, 30)
+      customer.free_trial_started_at = Time.utc(2016, 2, 2, 22, 40)
       customer.attributes[:tags] = [:wurst]
       customer.attributes[:custom][:meinung] = [:lecker]
 
@@ -280,7 +280,7 @@ describe ChartMogul::Customer do
       updated_customer = described_class.retrieve(customer_uuid)
       expect(updated_customer.name).to eq 'Currywurst'
       expect(updated_customer.email).to eq 'curry@wurst.com'
-      expect(updated_customer.address).to eq({ country: 'Germany', state: 'New York', city: 'Berlin', address_zip: nil})
+      expect(updated_customer.address).to eq(country: 'Germany', state: 'New York', city: 'Berlin', address_zip: nil)
       expect(updated_customer.attributes[:tags]).to eq ['wurst']
       expect(updated_customer.attributes[:custom][:meinung]).to eq ['lecker']
     end

--- a/spec/chartmogul/data_source_spec.rb
+++ b/spec/chartmogul/data_source_spec.rb
@@ -18,7 +18,7 @@ describe ChartMogul::DataSource do
       {
         name: 'Test Data Source',
         uuid: 'abcd-1234',
-        created_at: "2016-06-05T15:33:34.000Z",
+        created_at: '2016-06-05T15:33:34.000Z',
         status: 'never_imported'
       }
     end
@@ -34,7 +34,7 @@ describe ChartMogul::DataSource do
     end
 
     it 'sets created_at' do
-      expect(subject.created_at).to eq(Time.utc(2016,06,05,15,33,34))
+      expect(subject.created_at).to eq(Time.utc(2016, 0o6, 0o5, 15, 33, 34))
     end
 
     it 'sets the status' do

--- a/spec/chartmogul/invoice_spec.rb
+++ b/spec/chartmogul/invoice_spec.rb
@@ -75,7 +75,7 @@ describe ChartMogul::Invoice do
           discount_code: 'DISCCODE',
           tax_amount_in_cents: 200,
           external_id: 'one_time_ext_id',
-          uuid: 'li_1234-5678-9012-34567',
+          uuid: 'li_1234-5678-9012-34567'
         ),
         ChartMogul::LineItems::OneTime.new(
           amount_in_cents: 1000,
@@ -84,19 +84,19 @@ describe ChartMogul::Invoice do
           discount_amount_in_cents: 1200,
           discount_code: 'DISCCODE',
           tax_amount_in_cents: 200,
-          external_id: 'one_time_ext_id',
+          external_id: 'one_time_ext_id'
         )
       ],
       transactions: [
         ChartMogul::Transactions::Payment.new(
           date: '2016-01-01 12:00:00',
           result: 'successful',
-          external_id: 'pay_ext_id',
+          external_id: 'pay_ext_id'
         ),
         ChartMogul::Transactions::Refund.new(
           date: '2016-01-01 12:00:00',
           result: 'successful',
-          external_id: 'ref_ext_id',
+          external_id: 'ref_ext_id'
         )
       ],
       external_id: 'inv_ext_id',
@@ -144,7 +144,7 @@ describe ChartMogul::Invoice do
     end
 
     it 'sets the date attribute' do
-      expect(subject.date).to eq(Time.parse '2016-01-01 12:00:00')
+      expect(subject.date).to eq(Time.parse('2016-01-01 12:00:00'))
     end
 
     it 'sets the currency attribute' do
@@ -168,7 +168,7 @@ describe ChartMogul::Invoice do
     end
 
     it 'sets the due_date attribute' do
-      expect(subject.due_date).to eq(Time.parse '2016-02-01 12:00:00')
+      expect(subject.due_date).to eq(Time.parse('2016-02-01 12:00:00'))
     end
   end
 
@@ -177,62 +177,62 @@ describe ChartMogul::Invoice do
 
     it 'returns a valid hash' do
       expect(subject.serialize_for_write).to eq(
-        date: "2016-01-01 12:00:00",
-        currency: "USD",
+        date: '2016-01-01 12:00:00',
+        currency: 'USD',
         line_items: [
           {
-            type: "subscription",
-            subscription_external_id: "sub_ext_id",
-            plan_uuid: "pl_1234-5678-9012-34567",
-            service_period_start: "2016-01-01 12:00:00",
-            service_period_end: "2016-02-01 12:00:00",
+            type: 'subscription',
+            subscription_external_id: 'sub_ext_id',
+            plan_uuid: 'pl_1234-5678-9012-34567',
+            service_period_start: '2016-01-01 12:00:00',
+            service_period_end: '2016-02-01 12:00:00',
             amount_in_cents: 1000,
-            cancelled_at: "2016-01-15 12:00:00",
+            cancelled_at: '2016-01-15 12:00:00',
             prorated: false,
             quantity: 5,
             discount_amount_in_cents: 1200,
-            discount_code: "DISCCODE",
+            discount_code: 'DISCCODE',
             tax_amount_in_cents: 200,
-            external_id: "one_time_ext_id"
+            external_id: 'one_time_ext_id'
           },
           {
-            type: "one_time",
+            type: 'one_time',
             amount_in_cents: 1000,
-            description: "Dummy Description",
+            description: 'Dummy Description',
             quantity: 5,
             discount_amount_in_cents: 1200,
-            discount_code: "DISCCODE",
+            discount_code: 'DISCCODE',
             tax_amount_in_cents: 200,
-            external_id: "one_time_ext_id"
+            external_id: 'one_time_ext_id'
           }
         ],
         transactions: [
           {
-            type: "payment",
-            date: "2016-01-01 12:00:00",
-            result: "successful",
-            external_id: "pay_ext_id"
+            type: 'payment',
+            date: '2016-01-01 12:00:00',
+            result: 'successful',
+            external_id: 'pay_ext_id'
           },
           {
-            type: "refund",
-            date: "2016-01-01 12:00:00",
-            result: "successful",
-            external_id: "ref_ext_id"
+            type: 'refund',
+            date: '2016-01-01 12:00:00',
+            result: 'successful',
+            external_id: 'ref_ext_id'
           }
         ],
-        external_id: "inv_ext_id",
-        due_date: "2016-02-01 12:00:00"
+        external_id: 'inv_ext_id',
+        due_date: '2016-02-01 12:00:00'
       )
     end
   end
   describe 'API Interactions', vcr: true do
     it 'returns all invoices through list all endpoint', uses_api: true do
-      invoices = described_class.all(per_page: 10, external_id: "invoice_eid")
-      expect(invoices.instance_of? ChartMogul::Invoices).to be true
+      invoices = described_class.all(per_page: 10, external_id: 'invoice_eid')
+      expect(invoices.instance_of?(ChartMogul::Invoices)).to be true
       expect(invoices.size).to eq 1
-      expect(invoices[0].instance_of? described_class).to be true
-      expect(invoices[0].external_id).to eq "invoice_eid"
-      expect(invoices[0].customer_uuid).to eq "customer_uuid"
+      expect(invoices[0].instance_of?(described_class)).to be true
+      expect(invoices[0].external_id).to eq 'invoice_eid'
+      expect(invoices[0].customer_uuid).to eq 'customer_uuid'
     end
 
     it 'deletes an invoice', uses_api: true do
@@ -247,7 +247,7 @@ describe ChartMogul::Invoice do
     it 'raises error on deleting non-existing invoice', uses_api: true do
       invoice = described_class.new
       invoice.instance_variable_set(:@uuid, 'inv_I_dont_exists') # hack-write private uuid
-      expect{invoice.destroy!}.to raise_error(ChartMogul::ChartMogulError)
+      expect { invoice.destroy! }.to raise_error(ChartMogul::ChartMogulError)
     end
 
     it 'retrieves existing invoice by uuid', uses_api: true do

--- a/spec/chartmogul/line_items/subscription_spec.rb
+++ b/spec/chartmogul/line_items/subscription_spec.rb
@@ -109,11 +109,11 @@ describe ChartMogul::LineItems::Subscription do
     end
 
     it 'sets the service_period_start attribute' do
-      expect(subject.service_period_start).to eq(Time.parse '2016-01-01 12:00:00')
+      expect(subject.service_period_start).to eq(Time.parse('2016-01-01 12:00:00'))
     end
 
     it 'sets the service_period_end attribute' do
-      expect(subject.service_period_end).to eq(Time.parse '2016-02-01 12:00:00')
+      expect(subject.service_period_end).to eq(Time.parse('2016-02-01 12:00:00'))
     end
 
     it 'sets the amount_in_cents attribute' do
@@ -121,7 +121,7 @@ describe ChartMogul::LineItems::Subscription do
     end
 
     it 'sets the cancelled_at attribute' do
-      expect(subject.cancelled_at).to eq(Time.parse '2016-01-15 12:00:00')
+      expect(subject.cancelled_at).to eq(Time.parse('2016-01-15 12:00:00'))
     end
 
     it 'sets the prorated attribute' do

--- a/spec/chartmogul/metrics/metrics_spec.rb
+++ b/spec/chartmogul/metrics/metrics_spec.rb
@@ -9,7 +9,7 @@ METRICS = {
   customer_churn_rate: ChartMogul::Metrics::CustomerChurnRate,
   customer_count: ChartMogul::Metrics::CustomerCount,
   mrr_churn_rate: ChartMogul::Metrics::MRRChurnRate
-}
+}.freeze
 
 METRICS.each do |method_name, klass_name|
   describe klass_name, vcr: true, uses_api: true do

--- a/spec/chartmogul/metrics/shared/metrics_resource.rb
+++ b/spec/chartmogul/metrics/shared/metrics_resource.rb
@@ -14,4 +14,3 @@ shared_examples 'Metrics API resource' do
     expect(entry.send(value_field)).not_to be_nil
   end
 end
-

--- a/spec/chartmogul/metrics/shared/pageable.rb
+++ b/spec/chartmogul/metrics/shared/pageable.rb
@@ -7,4 +7,3 @@ shared_examples 'Pageable' do
     expect(response.per_page).not_to be_nil
   end
 end
-

--- a/spec/chartmogul/metrics/subscriptions_spec.rb
+++ b/spec/chartmogul/metrics/subscriptions_spec.rb
@@ -28,4 +28,3 @@ describe ChartMogul::Metrics::Subscription, vcr: true, uses_api: true do
     expect(subscription.currency_sign).not_to be_nil
   end
 end
-

--- a/spec/chartmogul/ping_spec.rb
+++ b/spec/chartmogul/ping_spec.rb
@@ -5,7 +5,7 @@ describe ChartMogul::Ping do
     it 'when credentials correct', uses_api: true do
       pong = ChartMogul::Ping.ping
 
-      expect(pong.data).to eq("pong!")
+      expect(pong.data).to eq('pong!')
     end
 
     it 'and fails on incorrect credentials', uses_api: true do

--- a/spec/chartmogul/plan_spec.rb
+++ b/spec/chartmogul/plan_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe ChartMogul::Plan do
   describe 'API Interactions', vcr: true do
     it 'correctly interacts with the API', uses_api: true do
-      data_source = ChartMogul::DataSource.create!(name:"Another Data Source")
+      data_source = ChartMogul::DataSource.create!(name: 'Another Data Source')
 
       plan = ChartMogul::Plan.create!(
         interval_count: 1,
-        interval_unit: "month",
-        name: "A Test Plan",
+        interval_unit: 'month',
+        name: 'A Test Plan',
         data_source_uuid: data_source.uuid
       )
 
@@ -27,12 +27,12 @@ describe ChartMogul::Plan do
     end
 
     it 'retrieves existing plan by uuid', uses_api: true do
-      data_source = ChartMogul::DataSource.create!(name:"Another Data Source")
+      data_source = ChartMogul::DataSource.create!(name: 'Another Data Source')
 
       plan = ChartMogul::Plan.create!(
         interval_count: 1,
-        interval_unit: "month",
-        name: "A Test Plan",
+        interval_unit: 'month',
+        name: 'A Test Plan',
         data_source_uuid: data_source.uuid
       )
       plan.send(:set_uuid, 'pl_5ee8bf93-b0b4-4722-8a17-6b624a3af072')
@@ -42,12 +42,12 @@ describe ChartMogul::Plan do
     end
 
     it 'updates existing plan', uses_api: true do
-      data_source = ChartMogul::DataSource.create!(name:"Another Data Source")
+      data_source = ChartMogul::DataSource.create!(name: 'Another Data Source')
 
       plan = ChartMogul::Plan.create!(
         interval_count: 1,
-        interval_unit: "month",
-        name: "A Test Plan",
+        interval_unit: 'month',
+        name: 'A Test Plan',
         data_source_uuid: data_source.uuid
       )
       plan.send(:set_uuid, 'pl_5ee8bf93-b0b4-4722-8a17-6b624a3af072')
@@ -60,12 +60,12 @@ describe ChartMogul::Plan do
     end
 
     it 'deletes existing plan', uses_api: true do
-      data_source = ChartMogul::DataSource.create!(name:"Another Data Source")
+      data_source = ChartMogul::DataSource.create!(name: 'Another Data Source')
 
       plan = ChartMogul::Plan.create!(
         interval_count: 1,
-        interval_unit: "month",
-        name: "A Test Plan",
+        interval_unit: 'month',
+        name: 'A Test Plan',
         data_source_uuid: data_source.uuid
       )
       plan.send(:set_uuid, 'pl_5ee8bf93-b0b4-4722-8a17-6b624a3af072')

--- a/spec/chartmogul/resource_path_spec.rb
+++ b/spec/chartmogul/resource_path_spec.rb
@@ -38,7 +38,7 @@ describe ChartMogul::ResourcePath do
       end
 
       it 'raises an exception if named parameter not passed' do
-        expect{subject.apply}.to raise_error(
+        expect { subject.apply }.to raise_error(
           ChartMogul::ResourcePath::RequiredParameterMissing, ':custom is required'
         )
       end
@@ -56,7 +56,7 @@ describe ChartMogul::ResourcePath do
       end
 
       it 'raises an exception if named parameter not passed' do
-        expect{subject.apply_with_get_params}.to raise_error(
+        expect { subject.apply_with_get_params }.to raise_error(
           ChartMogul::ResourcePath::RequiredParameterMissing, ':custom is required'
         )
       end

--- a/spec/chartmogul/subscription_spec.rb
+++ b/spec/chartmogul/subscription_spec.rb
@@ -38,35 +38,34 @@ describe ChartMogul::Subscription do
         invoices: [invoice]
       ).create!
 
-
       expect(customer.subscriptions.current_page).to eq(1)
       expect(customer.subscriptions.total_pages).to eq(1)
       expect(customer.subscriptions.size).to eq(1)
-      expect(customer.subscriptions.first.uuid).to eq("sub_9b3ccf25-4613-4af6-84b3-12026cfa4b7c")
-      expect(customer.subscriptions.first.data_source_uuid).to eq("ds_55ab11fb-53e6-4468-aa95-bd582f14cac6")
-      expect(customer.subscriptions.first.external_id).to eq("test_cus_sub_ext_id")
+      expect(customer.subscriptions.first.uuid).to eq('sub_9b3ccf25-4613-4af6-84b3-12026cfa4b7c')
+      expect(customer.subscriptions.first.data_source_uuid).to eq('ds_55ab11fb-53e6-4468-aa95-bd582f14cac6')
+      expect(customer.subscriptions.first.external_id).to eq('test_cus_sub_ext_id')
 
       customer.subscriptions.first.cancel(Time.utc(2016, 1, 15, 12))
 
       expect(customer.subscriptions.first.cancellation_dates).to match_array(
-        [Time.utc(2016, 01,15, 12)]
+        [Time.utc(2016, 1, 15, 12)]
       )
 
       data_source.destroy!
     end
 
     it 'has multiple aliases', uses_api: true do
-      subscriptions = described_class.all("cus_510b1395-4fe8-4d35-ae23-0e61f9a51e33", {page: 1, per_page: 2})
+      subscriptions = described_class.all('cus_510b1395-4fe8-4d35-ae23-0e61f9a51e33', page: 1, per_page: 2)
       expect(subscriptions.current_page).to eq(1)
       expect(subscriptions.total_pages).to eq(1)
       expect(subscriptions.size).to eq(1)
-      expect(subscriptions.first.uuid).to eq("sub_9b3ccf25-4613-4af6-84b3-12026cfa4b7c")
+      expect(subscriptions.first.uuid).to eq('sub_9b3ccf25-4613-4af6-84b3-12026cfa4b7c')
 
-      subscriptions = ChartMogul::Subscriptions.all("cus_510b1395-4fe8-4d35-ae23-0e61f9a51e33", {page: 2, per_page: 1})
+      subscriptions = ChartMogul::Subscriptions.all('cus_510b1395-4fe8-4d35-ae23-0e61f9a51e33', page: 2, per_page: 1)
       expect(subscriptions.current_page).to eq(2)
       expect(subscriptions.total_pages).to eq(2)
       expect(subscriptions.size).to eq(1)
-      expect(subscriptions.first.uuid).to eq("sub_9b3ccf25-4613-4af6-84b3-12026cfa4b7c")
+      expect(subscriptions.first.uuid).to eq('sub_9b3ccf25-4613-4af6-84b3-12026cfa4b7c')
     end
   end
 end

--- a/spec/chartmogul/transactions/payment_spec.rb
+++ b/spec/chartmogul/transactions/payment_spec.rb
@@ -46,7 +46,7 @@ describe ChartMogul::Transactions::Payment do
     end
 
     it 'sets the date attribute' do
-      expect(subject.date).to eq(Time.parse '2016-01-01 12:00:00')
+      expect(subject.date).to eq(Time.parse('2016-01-01 12:00:00'))
     end
 
     it 'sets the result attribute' do

--- a/spec/chartmogul/transactions/refund_spec.rb
+++ b/spec/chartmogul/transactions/refund_spec.rb
@@ -46,7 +46,7 @@ describe ChartMogul::Transactions::Refund do
     end
 
     it 'sets the date attribute' do
-      expect(subject.date).to eq(Time.parse '2016-01-01 12:00:00')
+      expect(subject.date).to eq(Time.parse('2016-01-01 12:00:00'))
     end
 
     it 'sets the result attribute' do

--- a/spec/chartmogul/utils/hash_snake_caser_spec.rb
+++ b/spec/chartmogul/utils/hash_snake_caser_spec.rb
@@ -17,9 +17,9 @@ describe ChartMogul::Utils::HashSnakeCaser do
     expect(subject.to_snake_keys).to eq(
       'key_key' => { 'with_nested_hash' => true },
       'and_array' => [{}],
-      :camel_cased_key => "with string",
-      :good_enough_key => "here is nothing to do",
-      :huge_symbols => "wow"
+      :camel_cased_key => 'with string',
+      :good_enough_key => 'here is nothing to do',
+      :huge_symbols => 'wow'
     )
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,13 +3,13 @@ require 'chartmogul'
 require 'vcr'
 
 VCR.configure do |config|
-  config.cassette_library_dir = "fixtures/vcr_cassettes"
+  config.cassette_library_dir = 'fixtures/vcr_cassettes'
   config.hook_into :faraday
   config.configure_rspec_metadata!
 end
 
 RSpec.configure do |config|
-  config.order = "random"
+  config.order = 'random'
 
   config.before(:each) do |example|
     if example.metadata[:uses_api]


### PR DESCRIPTION
* just formatting things (`rubocop -a` @ 0.49.1)
* bumping up version to 1.1.5, so we can release #43 