### PR TITLE
Fix ChartMogul::ChartMogulError class

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # chartmogul-ruby Change Log
 
+## Version 1.1.8 - 22 June 2018
+- Fix ChartMogul::ChartMogulError class
+
 ## Version 1.0.2 - 6 March 2017
 - Consolidated Customer, Enrichment/Customer now deprecated
 

--- a/lib/chartmogul/errors/chartmogul_error.rb
+++ b/lib/chartmogul/errors/chartmogul_error.rb
@@ -1,19 +1,19 @@
 module ChartMogul
   class ChartMogulError < StandardError
-    attr_accessor :message
-    attr_accessor :response
-    attr_accessor :http_status
+    attr_reader :error_message, :response, :http_status
 
-    def initialize(message, http_status: nil, response: nil)
-      @message = message
+    def initialize(error_message, http_status: nil, response: nil)
+      @error_message = error_message
       @http_status = http_status
       @response = response
+
+      super(build_message)
     end
 
-    def to_s
-      status = @http_status ? " (HTTP Status: #{@http_status})" : ''
-      response = @response ? "\nResponse: #{@response}" : ''
-      "#{message}#{status}#{response}"
+    def build_message
+      status = http_status ? " (HTTP Status: #{http_status})" : ''
+      resp = response ? "\nResponse: #{response}" : ''
+      "#{error_message}#{status}#{resp}"
     end
   end
 end

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,3 +1,3 @@
 module ChartMogul
-  VERSION = '1.1.7'.freeze
+  VERSION = '1.1.8'.freeze
 end

--- a/spec/chartmogul/customer_spec.rb
+++ b/spec/chartmogul/customer_spec.rb
@@ -290,15 +290,22 @@ describe ChartMogul::Customer do
       customer = described_class.retrieve(customer_uuid)
 
       customer.email = 'schnitzel.com'
+
+      error_message = "The Customer could not be created or updated. (HTTP Status: 422)\n"\
+        'Response: {"code":422,"message":"The value provided does not appear to be '\
+        'a valid email address.","param":"email"}'
+
       expect do
         customer.update!
-      end.to raise_error(ChartMogul::ResourceInvalidError, 'The Customer could not be created or updated.')
+      end.to raise_error(ChartMogul::ResourceInvalidError, error_message)
     end
 
     it 'raises 401 if invalid credentials', uses_api: true do
+      error_message = "No valid API key provided (HTTP Status: 401)\n"\
+        'Response: {"code":401,"message":"No valid API key provided","param":null}'
       expect do
         described_class.all(per_page: 10)
-      end.to raise_error(ChartMogul::UnauthorizedError, 'No valid API key provided')
+      end.to raise_error(ChartMogul::UnauthorizedError, error_message)
     end
   end
 end


### PR DESCRIPTION
Stops overriding `#message` method of StandardError class.
Uses customer error message.
Fixes tests.

When the error was raised It used to print/log only first `message` argument passed to the class instead of using `#to_s` method.
The reason is that `#message` method was overriden by `attr_accessor: :message` line.
