### PR TITLE
Retry requests on certain statuses and allow config [ch3381]

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ You can find examples for each endpoint in the ChartMogul [API documentation](ht
 
 [![https://gyazo.com/f7a2a1b86a409586ee8dd0f4f7563937](https://i.gyazo.com/f7a2a1b86a409586ee8dd0f4f7563937.gif)](https://i.gyazo.com/f7a2a1b86a409586ee8dd0f4f7563937.gif)
 
+## Rate Limits & Exponential Backoff
+
+The library will keep retrying if the request exceeds the rate limit or if there's any network related error. By default, the request will be retried for 20 times (approximated 15 minutes) before finally giving up.
+
+You can change the retry count with:
+
+ChartMogul.max_retries = 15
+
+Set it to 0 to disable it.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ You can find examples for each endpoint in the ChartMogul [API documentation](ht
 The library will keep retrying if the request exceeds the rate limit or if there's any network related error. By default, the request will be retried for 20 times (approximated 15 minutes) before finally giving up.
 
 You can change the retry count with:
-
+```ruby
 ChartMogul.max_retries = 15
-
+```
 Set it to 0 to disable it.
 
 ## Development

--- a/chartmogul-ruby.gemspec
+++ b/chartmogul-ruby.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'vcr', '~> 3.0'
   spec.add_development_dependency 'pry', '~> 0.10.3'
+  spec.add_development_dependency 'webmock', '~> 3.4.2'
 end

--- a/lib/chartmogul.rb
+++ b/lib/chartmogul.rb
@@ -67,6 +67,7 @@ require 'chartmogul/enrichment/customer'
 
 module ChartMogul
   API_BASE = 'https://api.chartmogul.com'.freeze
+  MAX_RETRIES = 20
 
   class << self
     extend ConfigAttributes
@@ -77,5 +78,6 @@ module ChartMogul
 
     config_accessor :account_token
     config_accessor :secret_key
+    config_accessor :max_retries, MAX_RETRIES
   end
 end

--- a/lib/chartmogul/api_resource.rb
+++ b/lib/chartmogul/api_resource.rb
@@ -4,6 +4,8 @@ module ChartMogul
   class APIResource < ChartMogul::Object
     extend Forwardable
 
+    RETRY_STATUSES = [429, *500..599].freeze
+
     class << self; attr_reader :resource_path, :resource_name, :resource_root_key end
 
     def self.set_resource_path(path)
@@ -22,6 +24,7 @@ module ChartMogul
       @connection ||= Faraday.new(url: ChartMogul::API_BASE) do |faraday|
         faraday.use Faraday::Request::BasicAuthentication, ChartMogul.account_token, ChartMogul.secret_key
         faraday.use Faraday::Response::RaiseError
+        faraday.request :retry, max: ChartMogul.max_retries, retry_statuses: RETRY_STATUSES
         faraday.use Faraday::Adapter::NetHttp
       end
     end

--- a/lib/chartmogul/api_resource.rb
+++ b/lib/chartmogul/api_resource.rb
@@ -6,10 +6,8 @@ module ChartMogul
 
     RETRY_STATUSES = [429, *500..599].freeze
     RETRY_EXCEPTIONS = [
-      Errno::ETIMEDOUT,
-      'Timeout::Error',
-      'Error::TimeoutError',
-      Faraday::Error::RetriableResponse
+      'Faraday::ConnectionFailed',
+      'Faraday::RetriableResponse'
     ].freeze
     BACKOFF_FACTOR = 2
     INTERVAL_RANDOMNESS = 0.5
@@ -35,8 +33,8 @@ module ChartMogul
         faraday.use Faraday::Request::BasicAuthentication, ChartMogul.account_token, ChartMogul.secret_key
         faraday.use Faraday::Response::RaiseError
         faraday.request :retry, max: ChartMogul.max_retries, retry_statuses: RETRY_STATUSES,
-          max_interval: MAX_INTERVAL, backoff_factor: BACKOFF_FACTOR, interval_randomness: INTERVAL_RANDOMNESS,
-          interval: INTERVAL, exceptions: RETRY_EXCEPTIONS
+          max_interval: MAX_INTERVAL, backoff_factor: BACKOFF_FACTOR,
+          interval_randomness: INTERVAL_RANDOMNESS, interval: INTERVAL, exceptions: RETRY_EXCEPTIONS
         faraday.use Faraday::Adapter::NetHttp
       end
     end

--- a/lib/chartmogul/config_attributes.rb
+++ b/lib/chartmogul/config_attributes.rb
@@ -1,8 +1,8 @@
 module ChartMogul
   module ConfigAttributes
-    def config_accessor(attribute)
+    def config_accessor(attribute, default_value = nil)
       define_method(attribute) do
-        attr = config.send(attribute)
+        attr = config.send(attribute) || default_value
         raise ConfigurationError, "Configuration for #{attribute} not set" if attr.nil?
         attr
       end

--- a/lib/chartmogul/configuration.rb
+++ b/lib/chartmogul/configuration.rb
@@ -2,5 +2,6 @@ module ChartMogul
   class Configuration
     attr_accessor :account_token
     attr_accessor :secret_key
+    attr_accessor :max_retries
   end
 end

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,3 +1,3 @@
 module ChartMogul
-  VERSION = '1.1.9'.freeze
+  VERSION = '1.2.0'.freeze
 end

--- a/spec/chartmogul/retry_spec.rb
+++ b/spec/chartmogul/retry_spec.rb
@@ -10,6 +10,7 @@ describe 'chartmogul retry request' do
       "ChartMogul::Configuration", account_token: 'dummy-token', secret_key: 'dummy-token', max_retries: max_retries
     )
     allow(ChartMogul).to receive(:config).and_return(config)
+    stub_const('ChartMogul::APIResource::INTERVAL', 0) # avoid waiting when running specs
   end
 
   describe 'API Interactions' do

--- a/spec/chartmogul/retry_spec.rb
+++ b/spec/chartmogul/retry_spec.rb
@@ -3,24 +3,25 @@ require 'spec_helper'
 describe 'chartmogul retry request' do
   let(:url) { "https://api.chartmogul.com/v1/customers/search?email=no@email.com" }
 
-  before do
-    stub_request(:get, url).to_return(status: 503, body: "", headers: {})
-    ChartMogul::Customers.instance_variable_set(:@connection, nil) # clearing memoized connection
-    config = instance_double(
-      "ChartMogul::Configuration", account_token: 'dummy-token', secret_key: 'dummy-token', max_retries: max_retries
-    )
-    allow(ChartMogul).to receive(:config).and_return(config)
-    stub_const('ChartMogul::APIResource::INTERVAL', 0) # avoid waiting when running specs
-  end
+  describe 'Server side failed requests' do
+    before do
+      stub_request(:get, url).to_return(status: 503, body: "", headers: {})
+      ChartMogul::Customers.instance_variable_set(:@connection, nil) # clearing memoized connection
+      config = instance_double(
+        "ChartMogul::Configuration", account_token: 'dummy-token',
+        secret_key: 'dummy-token', max_retries: max_retries
+      )
+      allow(ChartMogul).to receive(:config).and_return(config)
+      stub_const('ChartMogul::APIResource::INTERVAL', 0) # avoid waiting when running specs
+    end
 
-  describe 'API Interactions' do
     context 'when retries are set' do
       let(:max_retries) { 20 }
 
       it 'retries the request before it dies' do
         VCR.turned_off do
           expect { ChartMogul::Customer.search('no@email.com') }.to raise_error(ChartMogul::ChartMogulError)
-          expect(WebMock).to have_requested( :get, url).times(21)
+          expect(WebMock).to have_requested(:get, url).times(21)
         end
       end
     end
@@ -32,6 +33,42 @@ describe 'chartmogul retry request' do
         VCR.turned_off do
           expect { ChartMogul::Customer.search('no@email.com') }.to raise_error(ChartMogul::ChartMogulError)
           expect(WebMock).to have_requested(:get, url).times(1)
+        end
+      end
+    end
+  end
+
+  describe 'Client side failed requests' do
+    let(:max_retries) { 20 }
+
+    before do
+      ChartMogul::Customers.instance_variable_set(:@connection, nil) # clearing memoized connection
+      config = instance_double(
+        "ChartMogul::Configuration", account_token: 'dummy-token',
+        secret_key: 'dummy-token', max_retries: max_retries
+      )
+      allow(ChartMogul).to receive(:config).and_return(config)
+      stub_const('ChartMogul::APIResource::INTERVAL', 0) # avoid waiting when running specs
+    end
+
+    context 'when it times out' do
+      before { stub_request(:get, url).to_timeout.times(10).then.to_return(status: 200, body: '{}') }
+
+      it 'retries the request' do
+        VCR.turned_off do
+          ChartMogul::Customer.search('no@email.com')
+          expect(WebMock).to have_requested(:get, url).times(11)
+        end
+      end
+    end
+
+    context 'when there is no connection' do
+      before { stub_request(:get, url).to_raise(SocketError).times(3).then.to_return(status: 200, body: '{}') }
+
+      it 'retries the request' do
+        VCR.turned_off do
+          ChartMogul::Customer.search('no@email.com')
+          expect(WebMock).to have_requested(:get, url).times(4)
         end
       end
     end

--- a/spec/chartmogul/retry_spec.rb
+++ b/spec/chartmogul/retry_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe 'chartmogul retry request' do
+  let(:url) { "https://api.chartmogul.com/v1/customers/search?email=no@email.com" }
+
+  before do
+    stub_request(:get, url).to_return(status: 503, body: "", headers: {})
+    ChartMogul::Customers.instance_variable_set(:@connection, nil) # clearing memoized connection
+    config = instance_double(
+      "ChartMogul::Configuration", account_token: 'dummy-token', secret_key: 'dummy-token', max_retries: max_retries
+    )
+    allow(ChartMogul).to receive(:config).and_return(config)
+  end
+
+  describe 'API Interactions' do
+    context 'when retries are set' do
+      let(:max_retries) { 20 }
+
+      it 'retries the request before it dies' do
+        VCR.turned_off do
+          expect { ChartMogul::Customer.search('no@email.com') }.to raise_error(ChartMogul::ChartMogulError)
+          expect(WebMock).to have_requested( :get, url).times(21)
+        end
+      end
+    end
+
+    context 'when retries are set to zero' do
+      let(:max_retries) { 0 }
+
+      it 'does not retry the request' do
+        VCR.turned_off do
+          expect { ChartMogul::Customer.search('no@email.com') }.to raise_error(ChartMogul::ChartMogulError)
+          expect(WebMock).to have_requested(:get, url).times(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'chartmogul'
 require 'vcr'
+require 'webmock/rspec'
 
 VCR.configure do |config|
   config.cassette_library_dir = 'fixtures/vcr_cassettes'


### PR DESCRIPTION
Making use of https://github.com/lostisland/faraday/blob/master/lib/faraday/request/retry.rb
retry request of statuses [429, 500-599] based on the max_retries setting.

Max retries can be configured using the ChartMogul configuration object.

