### PR TITLE
Update webmock version spec

### DIFF
--- a/chartmogul-ruby.gemspec
+++ b/chartmogul-ruby.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'vcr', '~> 3.0'
   spec.add_development_dependency 'pry', '~> 0.10.3'
-  spec.add_development_dependency 'webmock', '~> 3.4.2'
+  spec.add_development_dependency 'webmock', '~> 3.4', '>= 3.4.2'
 end


### PR DESCRIPTION
Fixes: 

WARNING:  pessimistic dependency on webmock (~> 3.4.2, development) may be overly strict