### PR TITLE
Subscription cancellation dates method issue [ch9984]

### DIFF
--- a/fixtures/vcr_cassettes/ChartMogul_Subscription/_update_cancellation_dates/when_array_has_time_objects/is_setting_the_cancellation_dates_of_the_subscription.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Subscription/_update_cancellation_dates/when_array_has_time_objects/is_setting_the_cancellation_dates_of_the_subscription.yml
@@ -1,0 +1,93 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/customers?external_id=test_cus_ext_id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic Hidden
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Mon, 04 Mar 2019 13:42:36 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '889'
+      connection:
+      - keep-alive
+      status:
+      - 200 OK
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"entries":[{"id":22661127,"uuid":"cus_b289bb4c-3e6f-11e9-b645-6369759fc9da","external_id":"test_cus_ext_id","name":"Test
+        Customer","email":"","status":"Active","customer-since":"2016-01-01T12:00:00+00:00","attributes":{"custom":{},"clearbit":{},"stripe":{},"tags":[]},"data_source_uuid":"ds_99d06d30-3e6f-11e9-b645-837bf5404a47","data_source_uuids":["ds_99d06d30-3e6f-11e9-b645-837bf5404a47"],"external_ids":["test_cus_ext_id"],"company":"","country":null,"state":null,"city":"","zip":null,"lead_created_at":null,"free_trial_started_at":null,"address":{"country":null,"state":null,"city":"","address_zip":null},"mrr":4348,"arr":52176,"billing-system-url":null,"chartmogul-url":"https://app.chartmogul.com/#customers/22661127-Test_Customer","billing-system-type":"Import
+        API","currency":"USD","currency-sign":"$"}],"current_page":1,"total_pages":1,"has_more":false,"per_page":200,"page":1}'
+    http_version:
+  recorded_at: Mon, 04 Mar 2019 13:42:37 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/import/customers/cus_b289bb4c-3e6f-11e9-b645-6369759fc9da/subscriptions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic Hidden
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Mon, 04 Mar 2019 13:42:37 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"326d93dd0e74d25754ea1611dc13afb0"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - b7b4c110-227a-4f93-b508-f7f1cea31597
+      x-runtime:
+      - '0.072499'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"customer_uuid":"cus_b289bb4c-3e6f-11e9-b645-6369759fc9da","subscriptions":[{"uuid":"sub_c2c97897-f0a0-4448-a035-043d7a19b845","external_id":"test_cus_sub_ext_id","cancellation_dates":[],"plan_uuid":"pl_933aefe0-209d-0137-2188-040113b1c101","data_source_uuid":"ds_99d06d30-3e6f-11e9-b645-837bf5404a47"}],"current_page":1,"total_pages":1}'
+    http_version:
+  recorded_at: Mon, 04 Mar 2019 13:42:37 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/ChartMogul_Subscription/_update_cancellation_dates/when_array_has_time_objects/is_setting_the_cancellation_dates_of_the_subscription.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Subscription/_update_cancellation_dates/when_array_has_time_objects/is_setting_the_cancellation_dates_of_the_subscription.yml
@@ -21,7 +21,7 @@ http_interactions:
       server:
       - nginx/1.10.1
       date:
-      - Mon, 04 Mar 2019 13:42:36 GMT
+      - Mon, 04 Mar 2019 15:04:12 GMT
       content-type:
       - application/json
       content-length:
@@ -38,7 +38,7 @@ http_interactions:
         Customer","email":"","status":"Active","customer-since":"2016-01-01T12:00:00+00:00","attributes":{"custom":{},"clearbit":{},"stripe":{},"tags":[]},"data_source_uuid":"ds_99d06d30-3e6f-11e9-b645-837bf5404a47","data_source_uuids":["ds_99d06d30-3e6f-11e9-b645-837bf5404a47"],"external_ids":["test_cus_ext_id"],"company":"","country":null,"state":null,"city":"","zip":null,"lead_created_at":null,"free_trial_started_at":null,"address":{"country":null,"state":null,"city":"","address_zip":null},"mrr":4348,"arr":52176,"billing-system-url":null,"chartmogul-url":"https://app.chartmogul.com/#customers/22661127-Test_Customer","billing-system-type":"Import
         API","currency":"USD","currency-sign":"$"}],"current_page":1,"total_pages":1,"has_more":false,"per_page":200,"page":1}'
     http_version:
-  recorded_at: Mon, 04 Mar 2019 13:42:37 GMT
+  recorded_at: Mon, 04 Mar 2019 15:04:12 GMT
 - request:
     method: get
     uri: https://api.chartmogul.com/v1/import/customers/cus_b289bb4c-3e6f-11e9-b645-6369759fc9da/subscriptions
@@ -60,7 +60,7 @@ http_interactions:
       server:
       - nginx/1.10.1
       date:
-      - Mon, 04 Mar 2019 13:42:37 GMT
+      - Mon, 04 Mar 2019 15:04:12 GMT
       content-type:
       - application/json; charset=utf-8
       transfer-encoding:
@@ -80,14 +80,59 @@ http_interactions:
       cache-control:
       - max-age=0, private, must-revalidate
       x-request-id:
-      - b7b4c110-227a-4f93-b508-f7f1cea31597
+      - ce3e2ca1-ac44-4e83-bad3-4418d5b9f99d
       x-runtime:
-      - '0.072499'
+      - '0.062006'
       strict-transport-security:
       - max-age=15768000
     body:
       encoding: ASCII-8BIT
       string: '{"customer_uuid":"cus_b289bb4c-3e6f-11e9-b645-6369759fc9da","subscriptions":[{"uuid":"sub_c2c97897-f0a0-4448-a035-043d7a19b845","external_id":"test_cus_sub_ext_id","cancellation_dates":[],"plan_uuid":"pl_933aefe0-209d-0137-2188-040113b1c101","data_source_uuid":"ds_99d06d30-3e6f-11e9-b645-837bf5404a47"}],"current_page":1,"total_pages":1}'
     http_version:
-  recorded_at: Mon, 04 Mar 2019 13:42:37 GMT
+  recorded_at: Mon, 04 Mar 2019 15:04:12 GMT
+- request:
+    method: patch
+    uri: https://api.chartmogul.com/v1/import/subscriptions/sub_c2c97897-f0a0-4448-a035-043d7a19b845
+    body:
+      encoding: UTF-8
+      string: '{"cancellation_dates":["2000-01-01 00:00:00 UTC"]}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic Hidden
+  response:
+    status:
+      code: 202
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Mon, 04 Mar 2019 15:04:13 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      cache-control:
+      - no-cache
+      x-request-id:
+      - d65b3ecf-9fbb-4c4b-b213-cdf17415cbc4
+      x-runtime:
+      - '0.125522'
+    body:
+      encoding: UTF-8
+      string: '{"uuid":"sub_c2c97897-f0a0-4448-a035-043d7a19b845","external_id":"test_cus_sub_ext_id","cancellation_dates":["2000-01-01T00:00:00.000Z"],"customer_uuid":"cus_b289bb4c-3e6f-11e9-b645-6369759fc9da","plan_uuid":"pl_933aefe0-209d-0137-2188-040113b1c101","data_source_uuid":"ds_99d06d30-3e6f-11e9-b645-837bf5404a47"}'
+    http_version:
+  recorded_at: Mon, 04 Mar 2019 15:04:13 GMT
 recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/ChartMogul_Subscription/_update_cancellation_dates/when_array_includes_invalid_entries/raises_an_exception.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Subscription/_update_cancellation_dates/when_array_includes_invalid_entries/raises_an_exception.yml
@@ -1,0 +1,93 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/customers?external_id=test_cus_ext_id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic Hidden
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Mon, 04 Mar 2019 12:51:15 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '889'
+      connection:
+      - keep-alive
+      status:
+      - 200 OK
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"entries":[{"id":22661127,"uuid":"cus_b289bb4c-3e6f-11e9-b645-6369759fc9da","external_id":"test_cus_ext_id","name":"Test
+        Customer","email":"","status":"Active","customer-since":"2016-01-01T12:00:00+00:00","attributes":{"custom":{},"clearbit":{},"stripe":{},"tags":[]},"data_source_uuid":"ds_99d06d30-3e6f-11e9-b645-837bf5404a47","data_source_uuids":["ds_99d06d30-3e6f-11e9-b645-837bf5404a47"],"external_ids":["test_cus_ext_id"],"company":"","country":null,"state":null,"city":"","zip":null,"lead_created_at":null,"free_trial_started_at":null,"address":{"country":null,"state":null,"city":"","address_zip":null},"mrr":4348,"arr":52176,"billing-system-url":null,"chartmogul-url":"https://app.chartmogul.com/#customers/22661127-Test_Customer","billing-system-type":"Import
+        API","currency":"USD","currency-sign":"$"}],"current_page":1,"total_pages":1,"has_more":false,"per_page":200,"page":1}'
+    http_version:
+  recorded_at: Mon, 04 Mar 2019 12:51:15 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/import/customers/cus_b289bb4c-3e6f-11e9-b645-6369759fc9da/subscriptions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic Hidden
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Mon, 04 Mar 2019 12:51:16 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"254e64ffb96f23cc2f16356dbd4e8051"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 8335a8c6-0279-479b-ba1d-c5be1d1bf9d4
+      x-runtime:
+      - '0.057060'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"customer_uuid":"cus_b289bb4c-3e6f-11e9-b645-6369759fc9da","subscriptions":[{"uuid":"sub_c2c97897-f0a0-4448-a035-043d7a19b845","external_id":"test_cus_sub_ext_id","cancellation_dates":["1999-12-31T22:00:00.000Z"],"plan_uuid":"pl_933aefe0-209d-0137-2188-040113b1c101","data_source_uuid":"ds_99d06d30-3e6f-11e9-b645-837bf5404a47"}],"current_page":1,"total_pages":1}'
+    http_version:
+  recorded_at: Mon, 04 Mar 2019 12:51:16 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/ChartMogul_Subscription/_update_cancellation_dates/when_array_includes_valid_entries/is_setting_the_cancellation_dates_of_the_subscription.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Subscription/_update_cancellation_dates/when_array_includes_valid_entries/is_setting_the_cancellation_dates_of_the_subscription.yml
@@ -1,0 +1,138 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/customers?external_id=test_cus_ext_id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic Hidden
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Mon, 04 Mar 2019 12:51:16 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '889'
+      connection:
+      - keep-alive
+      status:
+      - 200 OK
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"entries":[{"id":22661127,"uuid":"cus_b289bb4c-3e6f-11e9-b645-6369759fc9da","external_id":"test_cus_ext_id","name":"Test
+        Customer","email":"","status":"Active","customer-since":"2016-01-01T12:00:00+00:00","attributes":{"custom":{},"clearbit":{},"stripe":{},"tags":[]},"data_source_uuid":"ds_99d06d30-3e6f-11e9-b645-837bf5404a47","data_source_uuids":["ds_99d06d30-3e6f-11e9-b645-837bf5404a47"],"external_ids":["test_cus_ext_id"],"company":"","country":null,"state":null,"city":"","zip":null,"lead_created_at":null,"free_trial_started_at":null,"address":{"country":null,"state":null,"city":"","address_zip":null},"mrr":4348,"arr":52176,"billing-system-url":null,"chartmogul-url":"https://app.chartmogul.com/#customers/22661127-Test_Customer","billing-system-type":"Import
+        API","currency":"USD","currency-sign":"$"}],"current_page":1,"total_pages":1,"has_more":false,"per_page":200,"page":1}'
+    http_version:
+  recorded_at: Mon, 04 Mar 2019 12:51:16 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/import/customers/cus_b289bb4c-3e6f-11e9-b645-6369759fc9da/subscriptions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic Hidden
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Mon, 04 Mar 2019 12:51:17 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"254e64ffb96f23cc2f16356dbd4e8051"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - '08593034-b32b-4941-aaf0-6fc712762a81'
+      x-runtime:
+      - '0.070115'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"customer_uuid":"cus_b289bb4c-3e6f-11e9-b645-6369759fc9da","subscriptions":[{"uuid":"sub_c2c97897-f0a0-4448-a035-043d7a19b845","external_id":"test_cus_sub_ext_id","cancellation_dates":["1999-12-31T22:00:00.000Z"],"plan_uuid":"pl_933aefe0-209d-0137-2188-040113b1c101","data_source_uuid":"ds_99d06d30-3e6f-11e9-b645-837bf5404a47"}],"current_page":1,"total_pages":1}'
+    http_version:
+  recorded_at: Mon, 04 Mar 2019 12:51:17 GMT
+- request:
+    method: patch
+    uri: https://api.chartmogul.com/v1/import/subscriptions/sub_c2c97897-f0a0-4448-a035-043d7a19b845
+    body:
+      encoding: UTF-8
+      string: '{"cancellation_dates":["2000-01-01 00:00:00 +0200"]}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic Mjk5ZjAyMjYzMDRkNThhNWZiYzFlNTcwOTdlZGU3Mjk6OWM4NWIwNGFkN2FjNzE2NTUwYTY1NjZhZWYwYzM5ZmU=
+  response:
+    status:
+      code: 202
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Mon, 04 Mar 2019 12:51:17 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      cache-control:
+      - no-cache
+      x-request-id:
+      - 737a7d3a-bac8-4cdc-8d8f-15056faab094
+      x-runtime:
+      - '0.127860'
+    body:
+      encoding: UTF-8
+      string: '{"uuid":"sub_c2c97897-f0a0-4448-a035-043d7a19b845","external_id":"test_cus_sub_ext_id","cancellation_dates":["1999-12-31T22:00:00.000Z"],"customer_uuid":"cus_b289bb4c-3e6f-11e9-b645-6369759fc9da","plan_uuid":"pl_933aefe0-209d-0137-2188-040113b1c101","data_source_uuid":"ds_99d06d30-3e6f-11e9-b645-837bf5404a47"}'
+    http_version:
+  recorded_at: Mon, 04 Mar 2019 12:51:17 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/ChartMogul_Subscription/_update_cancellation_dates/when_array_is_empty/makes_an_API_call_and_removes_the_cancellation_dates.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Subscription/_update_cancellation_dates/when_array_is_empty/makes_an_API_call_and_removes_the_cancellation_dates.yml
@@ -1,0 +1,138 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/customers?external_id=test_cus_ext_id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic Hidden
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Mon, 04 Mar 2019 12:51:17 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '889'
+      connection:
+      - keep-alive
+      status:
+      - 200 OK
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"entries":[{"id":22661127,"uuid":"cus_b289bb4c-3e6f-11e9-b645-6369759fc9da","external_id":"test_cus_ext_id","name":"Test
+        Customer","email":"","status":"Active","customer-since":"2016-01-01T12:00:00+00:00","attributes":{"custom":{},"clearbit":{},"stripe":{},"tags":[]},"data_source_uuid":"ds_99d06d30-3e6f-11e9-b645-837bf5404a47","data_source_uuids":["ds_99d06d30-3e6f-11e9-b645-837bf5404a47"],"external_ids":["test_cus_ext_id"],"company":"","country":null,"state":null,"city":"","zip":null,"lead_created_at":null,"free_trial_started_at":null,"address":{"country":null,"state":null,"city":"","address_zip":null},"mrr":4348,"arr":52176,"billing-system-url":null,"chartmogul-url":"https://app.chartmogul.com/#customers/22661127-Test_Customer","billing-system-type":"Import
+        API","currency":"USD","currency-sign":"$"}],"current_page":1,"total_pages":1,"has_more":false,"per_page":200,"page":1}'
+    http_version:
+  recorded_at: Mon, 04 Mar 2019 12:51:17 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/import/customers/cus_b289bb4c-3e6f-11e9-b645-6369759fc9da/subscriptions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic Hidden
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Mon, 04 Mar 2019 12:51:18 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"254e64ffb96f23cc2f16356dbd4e8051"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - feb37862-a362-4a35-898b-58677e08f554
+      x-runtime:
+      - '0.061015'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"customer_uuid":"cus_b289bb4c-3e6f-11e9-b645-6369759fc9da","subscriptions":[{"uuid":"sub_c2c97897-f0a0-4448-a035-043d7a19b845","external_id":"test_cus_sub_ext_id","cancellation_dates":["1999-12-31T22:00:00.000Z"],"plan_uuid":"pl_933aefe0-209d-0137-2188-040113b1c101","data_source_uuid":"ds_99d06d30-3e6f-11e9-b645-837bf5404a47"}],"current_page":1,"total_pages":1}'
+    http_version:
+  recorded_at: Mon, 04 Mar 2019 12:51:18 GMT
+- request:
+    method: patch
+    uri: https://api.chartmogul.com/v1/import/subscriptions/sub_c2c97897-f0a0-4448-a035-043d7a19b845
+    body:
+      encoding: UTF-8
+      string: '{"cancellation_dates":[]}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic Mjk5ZjAyMjYzMDRkNThhNWZiYzFlNTcwOTdlZGU3Mjk6OWM4NWIwNGFkN2FjNzE2NTUwYTY1NjZhZWYwYzM5ZmU=
+  response:
+    status:
+      code: 202
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Mon, 04 Mar 2019 12:51:18 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      cache-control:
+      - no-cache
+      x-request-id:
+      - 76ef1912-9ef8-4bc7-b56f-4e09e230be06
+      x-runtime:
+      - '0.135980'
+    body:
+      encoding: UTF-8
+      string: '{"uuid":"sub_c2c97897-f0a0-4448-a035-043d7a19b845","external_id":"test_cus_sub_ext_id","cancellation_dates":[],"customer_uuid":"cus_b289bb4c-3e6f-11e9-b645-6369759fc9da","plan_uuid":"pl_933aefe0-209d-0137-2188-040113b1c101","data_source_uuid":"ds_99d06d30-3e6f-11e9-b645-837bf5404a47"}'
+    http_version:
+  recorded_at: Mon, 04 Mar 2019 12:51:18 GMT
+recorded_with: VCR 3.0.3

--- a/lib/chartmogul/subscription.rb
+++ b/lib/chartmogul/subscription.rb
@@ -38,7 +38,7 @@ module ChartMogul
     end
 
     def parse_dates(dates)
-      dates.map { |date| Time.parse(date) }
+      dates.map { |date| Time.parse(date.to_s) }
     end
   end
 

--- a/lib/chartmogul/subscription.rb
+++ b/lib/chartmogul/subscription.rb
@@ -13,10 +13,6 @@ module ChartMogul
 
     include API::Actions::Custom
 
-    def set_cancellation_dates(cancellation_dates_array)
-      @cancellation_dates = parse_dates(cancellation_dates_array)
-    end
-
     def update_cancellation_dates(cancellation_dates_array)
       cancellation_dates = parse_dates(cancellation_dates_array)
       custom!(:patch, "/v1/import/subscriptions/#{uuid}", cancellation_dates: cancellation_dates)
@@ -36,6 +32,10 @@ module ChartMogul
     end
 
     private
+
+    def set_cancellation_dates(cancellation_dates_array)
+      @cancellation_dates = parse_dates(cancellation_dates_array)
+    end
 
     def parse_dates(dates)
       dates.map { |date| Time.parse(date) }

--- a/lib/chartmogul/subscription.rb
+++ b/lib/chartmogul/subscription.rb
@@ -14,9 +14,12 @@ module ChartMogul
     include API::Actions::Custom
 
     def set_cancellation_dates(cancellation_dates_array)
-      @cancellation_dates = cancellation_dates_array.map do |cancellation_date|
-        Time.parse(cancellation_date)
-      end
+      @cancellation_dates = parse_dates(cancellation_dates_array)
+    end
+
+    def update_cancellation_dates(cancellation_dates_array)
+      cancellation_dates = parse_dates(cancellation_dates_array)
+      custom!(:patch, "/v1/import/subscriptions/#{uuid}", cancellation_dates: cancellation_dates)
     end
 
     def cancel(cancelled_at)
@@ -30,6 +33,12 @@ module ChartMogul
 
     def self.all(customer_uuid, options = {})
       Subscriptions.all(customer_uuid, options)
+    end
+
+    private
+
+    def parse_dates(dates)
+      dates.map { |date| Time.parse(date) }
     end
   end
 

--- a/spec/chartmogul/subscription_spec.rb
+++ b/spec/chartmogul/subscription_spec.rb
@@ -153,6 +153,8 @@ describe ChartMogul::Subscription do
 
     subject { subscription.update_cancellation_dates(dates) }
 
+    before { WebMock.allow_net_connect! }
+
     describe 'when array is empty' do
       let(:dates) { [] }
 
@@ -165,7 +167,7 @@ describe ChartMogul::Subscription do
       let(:dates) { ['invalid_entry'] }
 
       it 'raises an exception' do
-        expect { subject }. to raise_error ArgumentError
+        expect { subject }. to raise_error(ArgumentError, 'no time information in "invalid_entry"')
       end
     end
 
@@ -174,6 +176,14 @@ describe ChartMogul::Subscription do
 
       it 'is setting the cancellation dates of the subscription' do
         expect(subject.cancellation_dates).to eq [Time.utc(1999, 12, 31, 22)]
+      end
+    end
+
+    describe 'when array has time objects' do
+      let(:dates) { [Time.utc(2000, 1, 1)] }
+
+      it 'is setting the cancellation dates of the subscription' do
+        expect { subject }.to raise_error(TypeError, 'no implicit conversion of Time into String')
       end
     end
   end

--- a/spec/chartmogul/subscription_spec.rb
+++ b/spec/chartmogul/subscription_spec.rb
@@ -145,4 +145,36 @@ describe ChartMogul::Subscription do
       data_source.destroy!
     end
   end
+
+  describe '#update_cancellation_dates', uses_api: true, vcr: true do
+    let(:external_id) { 'test_cus_ext_id' }
+    let(:customer) { ChartMogul::Customer.all(external_id: external_id).first }
+    let(:subscription) { customer.subscriptions.first }
+
+    subject { subscription.update_cancellation_dates(dates) }
+
+    describe 'when array is empty' do
+      let(:dates) { [] }
+
+      it 'makes an API call and removes the cancellation dates' do
+        expect(subject.cancellation_dates).to eq []
+      end
+    end
+
+    describe 'when array includes invalid entries' do
+      let(:dates) { ['invalid_entry'] }
+
+      it 'raises an exception' do
+        expect { subject }. to raise_error ArgumentError
+      end
+    end
+
+    describe 'when array includes valid entries' do
+      let(:dates) { ['2000-01-01'] }
+
+      it 'is setting the cancellation dates of the subscription' do
+        expect(subject.cancellation_dates).to eq [Time.utc(1999, 12, 31, 22)]
+      end
+    end
+  end
 end

--- a/spec/chartmogul/subscription_spec.rb
+++ b/spec/chartmogul/subscription_spec.rb
@@ -183,7 +183,7 @@ describe ChartMogul::Subscription do
       let(:dates) { [Time.utc(2000, 1, 1)] }
 
       it 'is setting the cancellation dates of the subscription' do
-        expect { subject }.to raise_error(TypeError, 'no implicit conversion of Time into String')
+        expect(subject.cancellation_dates).to eq [Time.utc(2000, 1, 1)]
       end
     end
   end


### PR DESCRIPTION
Problem: `set_cancellation_dates method` on Subscriptions doesn't actually invoke the relevant API call (https://github.com/chartmogul/chartmogul-ruby/blob/master/lib/chartmogul/subscription.rb#L16)

Suggested Solution:
I cannot make the setter send an API request to set the cancellation dates because it will generate unexpected API requests. Also, it is used in various ways and it is not the expected behavior.
I added an update_cancellation_dates for that purpose. 
We will need to update our documentation and make sure the setter is used only for setting the object attributes. That's the intended behavior.