### PR TITLE
add #last method to Entries

### DIFF
--- a/lib/chartmogul/concerns/entries.rb
+++ b/lib/chartmogul/concerns/entries.rb
@@ -11,7 +11,7 @@ module ChartMogul
           include API::Actions::All
 
           include Enumerable
-          def_delegators @resource_root_key, :each, :[], :<<, :size, :length, :empty?, :first
+          def_delegators @resource_root_key, :each, :[], :<<, :size, :length, :empty?, :first, :last
 
           resource_root_key = @resource_root_key.to_s
           base.send :define_method, 'set_' + resource_root_key do |entries|


### PR DESCRIPTION
Hi! I've noticed that the documentation [on the ChartMogul API website](https://dev.chartmogul.com/v1.0/reference#delete-a-data-source) shows an example of using method `DataSources#last`, but this method is not defined.
This PR defines it. 
Thanks for the great library!