### PR TITLE
String parsed as time [ch15731]

### DIFF
--- a/chartmogul-ruby.gemspec
+++ b/chartmogul-ruby.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'vcr', '~> 3.0'
-  spec.add_development_dependency 'pry', '~> 0.10.3'
   spec.add_development_dependency 'webmock', '~> 3.4', '>= 3.4.2'
   spec.add_development_dependency 'simplecov', '~> 0.16.0'
+  spec.add_development_dependency 'pry', '~> 0.12.2'
 end

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/updates_custom_attributes.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/updates_custom_attributes.yml
@@ -75,8 +75,7 @@ http_interactions:
       - 'true'
     body:
       encoding: UTF-8
-      string: '{"custom":{"string_key":"Another String Value","integer_key":5678,"timestamp_key":"2016-02-01
-        00:00:00 UTC","boolean_key":false}}'
+      string: '{"custom":{"string_key":"Another String Value","integer_key":5678,"timestamp_key":"2016-02-01T00:00:00.000Z","boolean_key":false}}'
     http_version:
   recorded_at: Wed, 29 Jun 2016 12:47:09 GMT
 recorded_with: VCR 3.0.3

--- a/lib/chartmogul/customer.rb
+++ b/lib/chartmogul/customer.rb
@@ -117,23 +117,12 @@ module ChartMogul
     end
 
     def custom_attributes=(custom_attributes = {})
-      @attributes[:custom] = typecast_custom_attributes(custom_attributes)
+      @attributes[:custom] = ChartMogul::Utils::JSONParser.typecast_custom_attributes(custom_attributes)
     end
 
     def set_attributes(attributes_attributes)
       @attributes = attributes_attributes
-      @attributes[:custom] = typecast_custom_attributes(attributes_attributes[:custom])
-    end
-
-    def typecast_custom_attributes(custom_attributes)
-      return {} unless custom_attributes
-      custom_attributes.each_with_object({}) do |(key, value), hash|
-        hash[key] = value.instance_of?(String) ? (begin
-                                                    Time.parse(value)
-                                                  rescue
-                                                    value
-                                                  end) : value
-      end
+      @attributes[:custom] = ChartMogul::Utils::JSONParser.typecast_custom_attributes(attributes_attributes[:custom])
     end
   end
 

--- a/lib/chartmogul/enrichment/customer.rb
+++ b/lib/chartmogul/enrichment/customer.rb
@@ -95,23 +95,12 @@ module ChartMogul
       end
 
       def custom_attributes=(custom_attributes = {})
-        @attributes[:custom] = typecast_custom_attributes(custom_attributes)
+        @attributes[:custom] = ChartMogul::Utils::JSONParser.typecast_custom_attributes(custom_attributes)
       end
 
       def set_attributes(attributes_attributes)
         @attributes = attributes_attributes
-        @attributes[:custom] = typecast_custom_attributes(attributes_attributes[:custom])
-      end
-
-      def typecast_custom_attributes(custom_attributes)
-        return {} unless custom_attributes
-        custom_attributes.each_with_object({}) do |(key, value), hash|
-          hash[key] = value.instance_of?(String) ? (begin
-                                                      Time.parse(value)
-                                                    rescue
-                                                      value
-                                                    end) : value
-        end
+        @attributes[:custom] = ChartMogul::Utils::JSONParser.typecast_custom_attributes(attributes_attributes[:custom])
       end
     end
 

--- a/lib/chartmogul/enrichment/customer.rb
+++ b/lib/chartmogul/enrichment/customer.rb
@@ -94,6 +94,7 @@ module ChartMogul
         @attributes[:tags] = tags
       end
 
+      # When passing timestamps, either use Time instance, or iso8601-parseable string.
       def custom_attributes=(custom_attributes = {})
         @attributes[:custom] = ChartMogul::Utils::JSONParser.typecast_custom_attributes(custom_attributes)
       end

--- a/lib/chartmogul/utils/json_parser.rb
+++ b/lib/chartmogul/utils/json_parser.rb
@@ -18,7 +18,7 @@ module ChartMogul
         def opt_string_to_time(value)
           return value unless value.instance_of?(String)
 
-          Time.iso8601(value) rescue value
+          Time.iso8601(value) rescue Time.rfc2822(value) rescue value
         end
       end
     end

--- a/lib/chartmogul/utils/json_parser.rb
+++ b/lib/chartmogul/utils/json_parser.rb
@@ -1,9 +1,25 @@
 module ChartMogul
   module Utils
     class JSONParser
-      def self.parse(json_string)
-        hash = JSON.parse(json_string, symbolize_names: true)
-        HashSnakeCaser.new(hash).to_snake_keys
+      class << self
+        def parse(json_string)
+          hash = JSON.parse(json_string, symbolize_names: true)
+          HashSnakeCaser.new(hash).to_snake_keys
+        end
+
+        def typecast_custom_attributes(custom_attributes)
+          return {} unless custom_attributes
+
+          custom_attributes.each_with_object({}) do |(key, value), hash|
+            hash[key] = opt_string_to_time(value)
+          end
+        end
+
+        def opt_string_to_time(value)
+          return value unless value.instance_of?(String)
+
+          Time.iso8601(value) rescue value
+        end
       end
     end
   end

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,3 +1,3 @@
 module ChartMogul
-  VERSION = '1.3.1'.freeze
+  VERSION = '1.3.2'.freeze
 end

--- a/spec/chartmogul/utils/json_parser_spec.rb
+++ b/spec/chartmogul/utils/json_parser_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe ChartMogul::Utils::JSONParser do
+  describe '::typecast_custom_attributes' do
+    it 'parses ISO 8601, returned by ChartMogul API' do
+      result = described_class.typecast_custom_attributes({attr: '2016-02-01T00:00:00.000Z'})
+      expect(result[:attr]).to be_instance_of(Time)
+    end
+
+    it 'parses RFC 2822' do
+      result = described_class.typecast_custom_attributes({attr: 'Fri, 30 Aug 2019 12:13:07 +0000'})
+      expect(result[:attr]).to be_instance_of(Time)
+    end
+
+    it "doesn't parse string vaguely looking like a date" do
+      result = described_class.typecast_custom_attributes({attr: 'May the force be with you.'})
+      expect(result[:attr]).to be_instance_of(String)
+    end
+  end
+end


### PR DESCRIPTION
Using `Time.parse` for general strings is problematic, because it just tries too hard to parse a date. So, we should instead only support ISO & RFC standard. Import API returns data in ISO format. Users of library can pass the `Time` objects, keeping custom parsing in their hands or they can parse ISO-formatted string.

Added unit tests and deduplicated the code a bit. The VCR was updated only after manually checking what Import API currently returns (it's been a while since recorded).