### PR TITLE
Add support for subscription sets [ch16168]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # chartmogul-ruby Change Log
 
-## Version 1.4.0 - 6 May 2019
+## Version 1.4.0 - 20 September 2019
 - Add support for subscription sets
 
 ## Version 1.3.1 - 6 May 2019

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # chartmogul-ruby Change Log
 
+## Version 1.4.0 - 6 May 2019
+- Add support for subscription sets
+
 ## Version 1.3.1 - 6 May 2019
 - Add #last method to Entries
 

--- a/fixtures/vcr_cassettes/ChartMogul_CustomerInvoices/API_Interactions/correctly_interracts_with_the_API.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_CustomerInvoices/API_Interactions/correctly_interracts_with_the_API.yml
@@ -206,7 +206,7 @@ http_interactions:
     uri: https://api.chartmogul.com/v1/import/customers/cus_5417b49e-7ea8-474a-b6bc-5bbb406c15c0/invoices
     body:
       encoding: UTF-8
-      string: '{"invoices":[{"date":"2016-01-01 12:00:00 +0000","currency":"USD","line_items":[{"type":"subscription","subscription_external_id":"test_cus_sub_ext_id","plan_uuid":"pl_209e4674-1258-4a35-8378-9b15c4086965","service_period_start":"2016-01-01
+      string: '{"invoices":[{"date":"2016-01-01 12:00:00 +0000","currency":"USD","line_items":[{"type":"subscription","subscription_external_id":"test_cus_sub_ext_id","subscription_set_external_id":"test_cus_set_ext_id","plan_uuid":"pl_209e4674-1258-4a35-8378-9b15c4086965","service_period_start":"2016-01-01
         12:00:00 +0000","service_period_end":"2016-02-01 12:00:00 +0000","amount_in_cents":1000,"cancelled_at":"2016-01-15
         12:00:00 +0000","prorated":false,"quantity":5,"discount_amount_in_cents":1200,"discount_code":"DISCCODE","tax_amount_in_cents":200,"external_id":"test_cus_li_ext_id"}],"transactions":[{"type":"payment","date":"2016-01-01
         12:00:00 +0000","result":"successful","external_id":"test_cus_tr_ext_id"}],"external_id":"test_cus_inv_ext_id","due_date":"2016-01-07

--- a/fixtures/vcr_cassettes/ChartMogul_Invoice/API_Interactions/returns_all_invoices_through_list_all_endpoint.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Invoice/API_Interactions/returns_all_invoices_through_list_all_endpoint.yml
@@ -36,7 +36,7 @@ http_interactions:
       - 'true'
     body:
       encoding: UTF-8
-      string: '{"invoices":[{"date":"2016-01-01 12:00:00 +0000","currency":"USD","line_items":[{"type":"subscription","subscription_external_id":"test_cus_sub_ext_id","plan_uuid":"pl_209e4674-1258-4a35-8378-9b15c4086965","service_period_start":"2016-01-01
+      string: '{"invoices":[{"date":"2016-01-01 12:00:00 +0000","currency":"USD","line_items":[{"type":"subscription","subscription_external_id":"test_cus_sub_ext_id", "subscription_set_external_id":"test_cus_set_ext_id","plan_uuid":"pl_209e4674-1258-4a35-8378-9b15c4086965","service_period_start":"2016-01-01
         12:00:00 +0000","service_period_end":"2016-02-01 12:00:00 +0000","amount_in_cents":1000,"cancelled_at":"2016-01-15
         12:00:00 +0000","prorated":false,"quantity":5,"discount_amount_in_cents":1200,"discount_code":"DISCCODE","tax_amount_in_cents":200,"external_id":"test_cus_li_ext_id"}],"transactions":[{"type":"payment","date":"2016-01-01
         12:00:00 +0000","result":"successful","external_id":"test_cus_tr_ext_id"}],"external_id":"invoice_eid","due_date":"2016-01-07

--- a/fixtures/vcr_cassettes/ChartMogul_Subscription/API_Interactions/correctly_interracts_with_the_API.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Subscription/API_Interactions/correctly_interracts_with_the_API.yml
@@ -157,7 +157,7 @@ http_interactions:
     uri: https://api.chartmogul.com/v1/import/customers/cus_510b1395-4fe8-4d35-ae23-0e61f9a51e33/invoices
     body:
       encoding: UTF-8
-      string: '{"invoices":[{"date":"2016-01-01 12:00:00 +0000","currency":"USD","line_items":[{"type":"subscription","subscription_external_id":"test_cus_sub_ext_id","plan_uuid":"pl_06ea83a9-f8c8-4ddd-a980-9ceffd27f107","service_period_start":"2016-01-01
+      string: '{"invoices":[{"date":"2016-01-01 12:00:00 +0000","currency":"USD","line_items":[{"type":"subscription","subscription_external_id":"test_cus_sub_ext_id", "subscription_set_external_id":"test_cus_set_ext_id", "plan_uuid":"pl_06ea83a9-f8c8-4ddd-a980-9ceffd27f107","service_period_start":"2016-01-01
         12:00:00 +0000","service_period_end":"2016-02-01 12:00:00 +0000","amount_in_cents":1000}],"external_id":"test_tr_inv_ext_id"}],"customer_uuid":"cus_510b1395-4fe8-4d35-ae23-0e61f9a51e33"}'
     headers:
       User-Agent:
@@ -248,7 +248,7 @@ http_interactions:
       - max-age=15768000
     body:
       encoding: UTF-8
-      string: '{"customer_uuid":"cus_510b1395-4fe8-4d35-ae23-0e61f9a51e33","subscriptions":[{"uuid":"sub_9b3ccf25-4613-4af6-84b3-12026cfa4b7c","external_id":"test_cus_sub_ext_id","cancellation_dates":[],"plan_uuid":"pl_06ea83a9-f8c8-4ddd-a980-9ceffd27f107","data_source_uuid":"ds_55ab11fb-53e6-4468-aa95-bd582f14cac6"}],"current_page":1,"total_pages":1}'
+      string: '{"customer_uuid":"cus_510b1395-4fe8-4d35-ae23-0e61f9a51e33","subscriptions":[{"uuid":"sub_9b3ccf25-4613-4af6-84b3-12026cfa4b7c","external_id":"test_cus_sub_ext_id", "subscription_set_external_id":"test_cus_set_ext_id","cancellation_dates":[],"plan_uuid":"pl_06ea83a9-f8c8-4ddd-a980-9ceffd27f107","data_source_uuid":"ds_55ab11fb-53e6-4468-aa95-bd582f14cac6"}],"current_page":1,"total_pages":1}'
     http_version:
   recorded_at: Thu, 23 Jun 2016 20:46:07 GMT
 - request:

--- a/lib/chartmogul/line_items/subscription.rb
+++ b/lib/chartmogul/line_items/subscription.rb
@@ -16,6 +16,7 @@ module ChartMogul
       writeable_attr :tax_amount_in_cents
       writeable_attr :transaction_fees_in_cents
       writeable_attr :external_id
+      writeable_attr :subscription_set_external_id
 
       readonly_attr :subscription_uuid
       writeable_attr :invoice_uuid

--- a/lib/chartmogul/subscription.rb
+++ b/lib/chartmogul/subscription.rb
@@ -5,6 +5,7 @@ module ChartMogul
 
     readonly_attr :uuid
     writeable_attr :external_id
+    writeable_attr :subscription_set_external_id
     readonly_attr :cancellation_dates, default: []
 
     readonly_attr :plan_uuid

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,3 +1,3 @@
 module ChartMogul
-  VERSION = '1.3.3'.freeze
+  VERSION = '1.4.0'.freeze
 end

--- a/spec/chartmogul/invoice_spec.rb
+++ b/spec/chartmogul/invoice_spec.rb
@@ -9,6 +9,7 @@ describe ChartMogul::Invoice do
         {
           type: 'subscription',
           subscription_external_id: 'sub_ext_id',
+          subscription_set_external_id: 'set_ext_id',
           plan_uuid: 'pl_1234-5678-9012-34567',
           service_period_start: '2016-01-01 12:00:00',
           service_period_end: '2016-02-01 12:00:00',
@@ -64,6 +65,7 @@ describe ChartMogul::Invoice do
       line_items: [
         ChartMogul::LineItems::Subscription.new(
           subscription_external_id: 'sub_ext_id',
+          subscription_set_external_id: 'set_ext_id',
           plan_uuid: 'pl_1234-5678-9012-34567',
           service_period_start: '2016-01-01 12:00:00',
           service_period_end: '2016-02-01 12:00:00',
@@ -183,6 +185,7 @@ describe ChartMogul::Invoice do
           {
             type: 'subscription',
             subscription_external_id: 'sub_ext_id',
+            subscription_set_external_id: 'set_ext_id',
             plan_uuid: 'pl_1234-5678-9012-34567',
             service_period_start: '2016-01-01 12:00:00',
             service_period_end: '2016-02-01 12:00:00',

--- a/spec/chartmogul/line_items/subscription_spec.rb
+++ b/spec/chartmogul/line_items/subscription_spec.rb
@@ -5,6 +5,7 @@ describe ChartMogul::LineItems::Subscription do
     {
       type: 'subscription',
       subscription_external_id: 'sub_ext_id',
+      subscription_set_external_id: 'set_ext_id',
       plan_uuid: 'pl_1234-5678-9012-34567',
       service_period_start: '2016-01-01 12:00:00',
       service_period_end: '2016-02-01 12:00:00',
@@ -38,6 +39,10 @@ describe ChartMogul::LineItems::Subscription do
 
     it 'sets the subscription_external_id attribute' do
       expect(subject.subscription_external_id).to eq('sub_ext_id')
+    end
+
+    it 'sets the subscription_set_external_id attribute' do
+      expect(subject.subscription_set_external_id).to eq('set_ext_id')
     end
 
     it 'sets the plan_uuid attribute' do
@@ -102,6 +107,10 @@ describe ChartMogul::LineItems::Subscription do
 
     it 'sets the subscription_external_id attribute' do
       expect(subject.subscription_external_id).to eq('sub_ext_id')
+    end
+
+    it 'sets the subscription_set_external_id attribute' do
+      expect(subject.subscription_set_external_id).to eq('set_ext_id')
     end
 
     it 'sets the plan_uuid attribute' do

--- a/spec/chartmogul/subscription_spec.rb
+++ b/spec/chartmogul/subscription_spec.rb
@@ -22,6 +22,7 @@ describe ChartMogul::Subscription do
 
       line_item = ChartMogul::LineItems::Subscription.new(
         subscription_external_id: 'test_cus_sub_ext_id',
+        subscription_set_external_id: 'test_cus_set_ext_id',
         plan_uuid: plan.uuid,
         service_period_start: Time.utc(2016, 1, 1, 12),
         service_period_end: Time.utc(2016, 2, 1, 12),
@@ -44,6 +45,7 @@ describe ChartMogul::Subscription do
       expect(customer.subscriptions.first.uuid).to eq('sub_9b3ccf25-4613-4af6-84b3-12026cfa4b7c')
       expect(customer.subscriptions.first.data_source_uuid).to eq('ds_55ab11fb-53e6-4468-aa95-bd582f14cac6')
       expect(customer.subscriptions.first.external_id).to eq('test_cus_sub_ext_id')
+      expect(customer.subscriptions.first.subscription_set_external_id).to eq('test_cus_set_ext_id')
 
       customer.subscriptions.first.cancel(Time.utc(2016, 1, 15, 12))
 


### PR DESCRIPTION
This PR allows for support for subscription sets. It adds a `subscription_set_external_id` attribute to the following objects.

1. `ChartMogul::LineItems::Subscription`
2. `ChartMogul::Subscription`

As I couldn't find the test account used for the VCR specs, I updated the JSON response manually in the vcr fixtures.

It also bumps the version to `1.4.0` as a minor release 
 >  MINOR version when you add functionality in a backwards-compatible manner