### PR TITLE
Separate ChartMogul::ServerError exception class 

### DIFF
--- a/fixtures/vcr_cassettes/ChartMogul_Ping/pings/and_fails_with_500_internal_server_error.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Ping/pings/and_fails_with_500_internal_server_error.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/ping
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic ZHVtbXktdG9rZW46ZHVtbXktdG9rZW4=
+  response:
+    status:
+      code: 500
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      cache-control:
+      - private
+      content-length:
+      - '25'
+      content-type:
+      - text/plain; charset=utf-8
+      access-control-allow-origin:
+      - "*"
+      date:
+      - Tue, 10 Dec 2019 07:43:50 GMT
+      connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: 500 Internal Server Error
+    http_version:
+  recorded_at: Tue, 10 Dec 2019 07:43:51 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/ChartMogul_Ping/pings/and_fails_with_504_gateway_timeout_error.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Ping/pings/and_fails_with_504_gateway_timeout_error.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/ping
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic ZHVtbXktdG9rZW46ZHVtbXktdG9rZW4=
+  response:
+    status:
+      code: 504
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      cache-control:
+      - private
+      content-length:
+      - '25'
+      content-type:
+      - text/plain; charset=utf-8
+      access-control-allow-origin:
+      - "*"
+      date:
+      - Tue, 10 Dec 2019 07:43:50 GMT
+      connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: 504 Gateway Timeout Error
+    http_version:
+  recorded_at: Tue, 10 Dec 2019 07:43:51 GMT
+recorded_with: VCR 3.0.3

--- a/lib/chartmogul.rb
+++ b/lib/chartmogul.rb
@@ -13,6 +13,7 @@ require 'chartmogul/errors/forbidden_error'
 require 'chartmogul/errors/not_found_error'
 require 'chartmogul/errors/resource_invalid_error'
 require 'chartmogul/errors/schema_invalid_error'
+require 'chartmogul/errors/server_error'
 require 'chartmogul/errors/unauthorized_error'
 
 require 'chartmogul/config_attributes'

--- a/lib/chartmogul/api_resource.rb
+++ b/lib/chartmogul/api_resource.rb
@@ -66,6 +66,9 @@ module ChartMogul
       when 422
         message = "The #{resource_name} could not be created or updated."
         raise ChartMogul::ResourceInvalidError.new(message, http_status: 422, response: response)
+      when 500..504
+        message = 'ChartMogul API server response error'
+        raise ChartMogul::ServerError.new(message, http_status: http_status, response: response)
       else
         message = "#{resource_name} request error has occurred."
         raise ChartMogul::ChartMogulError.new(message, http_status: http_status, response: response)

--- a/lib/chartmogul/errors/server_error.rb
+++ b/lib/chartmogul/errors/server_error.rb
@@ -1,0 +1,4 @@
+module ChartMogul
+  class ServerError < ChartMogulError
+  end
+end

--- a/spec/chartmogul/ping_spec.rb
+++ b/spec/chartmogul/ping_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe ChartMogul::Ping do
+  before do
+    allow(ChartMogul).to receive(:max_retries).and_return(0)
+  end
   describe 'pings', vcr: true do
     it 'when credentials correct', uses_api: true do
       pong = ChartMogul::Ping.ping
@@ -10,6 +13,14 @@ describe ChartMogul::Ping do
 
     it 'and fails on incorrect credentials', uses_api: true do
       expect { ChartMogul::Ping.ping }.to raise_error(ChartMogul::UnauthorizedError)
+    end
+
+    it 'and fails with 500 internal server error', uses_api: true do
+      expect { ChartMogul::Ping.ping }.to raise_error(ChartMogul::ServerError)
+    end
+
+    it 'and fails with 504 gateway timeout error', uses_api: true do
+      expect { ChartMogul::Ping.ping }.to raise_error(ChartMogul::ServerError)
     end
   end
 end


### PR DESCRIPTION
for 500..504 response codes.
As example for rescue in background job unlike common ChartMogul::ChartMogulError.