### PR TITLE
Implement support for PlanGroup CRUD actions [ch19221]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # chartmogul-ruby Change Log
 
+## Version 1.5.0 - 20 February 2020
+- Add support for plan groups API
+
 ## Version 1.4.0 - 20 September 2019
 - Add support for subscription sets
 

--- a/chartmogul-ruby.gemspec
+++ b/chartmogul-ruby.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '~> 0.15.0'
 
-  spec.add_development_dependency 'bundler', '~> 2.0.1'
+  spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'vcr', '~> 3.0'

--- a/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/correctly_handles_a_422_error.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/correctly_handles_a_422_error.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plan_groups
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 422
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Wed, 12 Feb 2020 17:06:03 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 422 Unprocessable Entity
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      cache-control:
+      - no-cache
+      x-request-id:
+      - 829dd1b4-e36e-49ec-8647-187294a7cb00
+      x-runtime:
+      - '0.654937'
+    body:
+      encoding: UTF-8
+      string: '{"plans":["Please provide uuids of the plans in the plan group"]}'
+    http_version: 
+  recorded_at: Wed, 12 Feb 2020 17:06:03 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/deletes_a_plan_group.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/deletes_a_plan_group.yml
@@ -1,0 +1,293 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/data_sources
+    body:
+      encoding: UTF-8
+      string: '{"name":"Data Source #1"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 201
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Wed, 12 Feb 2020 16:50:58 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '152'
+      connection:
+      - close
+      status:
+      - 201 Created
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"uuid":"ds_d7af0870-4db7-11ea-a748-3b84121ebe17","name":"Data Source
+        #1","system":"Import API","created_at":"2020-02-12T16:50:57.869Z","status":"idle"}'
+    http_version: 
+  recorded_at: Wed, 12 Feb 2020 16:50:58 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plans
+    body:
+      encoding: UTF-8
+      string: '{"name":"A Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_d7af0870-4db7-11ea-a748-3b84121ebe17"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 201
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Wed, 12 Feb 2020 16:50:59 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 201 Created
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"e53de700ad9f3d935b0f624a5aa9dd75"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - f50dbc50-74e2-434e-a410-4601fdabd841
+      x-runtime:
+      - '0.723144'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"c49a57f0-2fe5-0138-b4fb-4e501129bd4a","name":"A Test
+        Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_d7af0870-4db7-11ea-a748-3b84121ebe17","uuid":"pl_c49a57f0-2fe5-0138-b4fb-4e501129bd4a"}'
+    http_version: 
+  recorded_at: Wed, 12 Feb 2020 16:50:59 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plans
+    body:
+      encoding: UTF-8
+      string: '{"name":"A another Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_d7af0870-4db7-11ea-a748-3b84121ebe17"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 201
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Wed, 12 Feb 2020 16:50:59 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 201 Created
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"6ee867f025f592d30a68042391ca1e58"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 24f68b11-c333-407b-be3d-9419055fec95
+      x-runtime:
+      - '0.138718'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"c4eade70-2fe5-0138-c99d-42eead14b4ad","name":"A another
+        Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_d7af0870-4db7-11ea-a748-3b84121ebe17","uuid":"pl_c4eade70-2fe5-0138-c99d-42eead14b4ad"}'
+    http_version: 
+  recorded_at: Wed, 12 Feb 2020 16:50:59 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plan_groups
+    body:
+      encoding: UTF-8
+      string: '{"name":"My plan group","plans":["pl_c49a57f0-2fe5-0138-b4fb-4e501129bd4a","pl_c4eade70-2fe5-0138-c99d-42eead14b4ad"]}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Wed, 12 Feb 2020 16:50:59 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"e5a42fa30f5931fa83c95f2b73f6747f"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 9d3b5349-86d5-40d4-89fc-a681a2fe7e10
+      x-runtime:
+      - '0.097957'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"My plan group","uuid":"plg_ca20004e-ed97-4942-9b7f-567a17bbbe31","plans":[{"name":"A
+        Test Plan","uuid":"pl_c49a57f0-2fe5-0138-b4fb-4e501129bd4a","data_source_uuid":"ds_d7af0870-4db7-11ea-a748-3b84121ebe17","interval_count":1,"interval_unit":"month","external_id":"c49a57f0-2fe5-0138-b4fb-4e501129bd4a"},{"name":"A
+        another Test Plan","uuid":"pl_c4eade70-2fe5-0138-c99d-42eead14b4ad","data_source_uuid":"ds_d7af0870-4db7-11ea-a748-3b84121ebe17","interval_count":1,"interval_unit":"month","external_id":"c4eade70-2fe5-0138-c99d-42eead14b4ad"}]}'
+    http_version: 
+  recorded_at: Wed, 12 Feb 2020 16:50:59 GMT
+- request:
+    method: delete
+    uri: https://api.chartmogul.com/v1/plan_groups/plg_ca20004e-ed97-4942-9b7f-567a17bbbe31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 204
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Wed, 12 Feb 2020 16:50:59 GMT
+      connection:
+      - close
+      status:
+      - 204 No Content
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      cache-control:
+      - no-cache
+      x-request-id:
+      - 86734092-41ca-4332-a0a5-7171ad0215f8
+      x-runtime:
+      - '0.160735'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 12 Feb 2020 16:50:59 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/plan_groups/plg_ca20004e-ed97-4942-9b7f-567a17bbbe31
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 404
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Wed, 12 Feb 2020 16:51:00 GMT
+      content-type:
+      - text/html; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      etag:
+      - W/"5e4412e9-7aa2"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        <!DOCTYPE html> <html lang="en" class="wf-loading"> <head> <meta charset="utf-8"> <title>Oops! That page doesn&#x27;t exist.</title> <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"> <meta name="HandheldFriendly" content="True"> <meta name="MobileOptimized" content="320"> <meta name="viewport" content="width=device-width,initial-scale=1"> <meta http-equiv="cleartype" content="on"> <style>/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */a,body{color:#13324B}.page-error .section-title,.section-title,body,h1{font-feature-settings:"kern" 1,"liga" 1,"calt" 1,"pnum" 1,"tnum" 0,"onum" 0,"lnum" 0,"dlig" 1}html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;font-size:10px;-webkit-tap-highlight-color:transparent}body{margin:0;font-family:"Source Sans Pro",sans-serif;font-size:16px;font-weight:400;line-height:1.4;background-color:#FFF;text-rendering:optimizeLegibility;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}article,header{display:block}a{background-color:transparent;text-decoration:none}a:active,a:hover{outline:0}h1{margin:.67em 0}a:focus,a:hover{color:#5A788A;text-decoration:underline}.page-error .section-title,.section-title,h1{font-family:inherit;font-weight:600;line-height:1.1;color:#13324B;margin-top:44px;margin-bottom:22px}.page-error .section-title,h1{font-size:41px}.section-title{font-size:36px}p{margin:0 0 11px}.section-description{font-size:118%}::-moz-selection{color:#fff;background:#8FA6B4}::selection{color:#fff;background:#8FA6B4}.wf-loading .page-error{transition:all .2s ease-in-out}@keyframes slide-in-from-bottom{0%{opacity:0;transform:translateY(60px)}100%{opacity:1;transform:translateY(0)}}.btn{transition:.2s ease-out;display:inline-block;margin-bottom:0;font-family:"Source Sans Pro",sans-serif;font-weight:600;text-align:center;text-transform:uppercase;letter-spacing:.015em;word-spacing:.05em;vertical-align:middle;-ms-touch-action:manipulation;touch-action:manipulation;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;cursor:pointer;background:0 0;border:1px solid transparent;white-space:nowrap;padding:8px 20px;font-size:15px;line-height:1.4}.btn:focus,.btn:hover{text-decoration:none}.btn:active{outline:0;background-image:none;transition:none}.btn-bordered{color:#FFF;background-color:transparent;border-color:#FFF}.btn-bordered:active,.btn-bordered:focus,.btn-bordered:hover{color:#000;background-color:#FFF;border-color:#FFF}.section-header:after,.section-header:before{content:" ";display:table}.section-header:after{clear:both}.section{padding-top:44px;padding-bottom:44px;overflow:hidden}.section-header{text-align:center;margin-bottom:44px}@media (min-width:768px){.section{padding-top:66px;padding-bottom:66px}.section-description,.section-title{max-width:100%;margin-left:auto;margin-right:auto}}@media (min-width:992px){.section-description,.section-title{max-width:90%}}.section-title{margin-top:0;margin-bottom:22px}.section-description{color:#13324B;margin-bottom:0}.section-actions,.section-description+.section-description{margin-top:22px}.section-actions .btn{margin-left:5px;margin-right:5px;min-width:200px}.logo{fill:#AAA;color:#AAA;width:135.5px;height:24.75px}.logo.logo-white{fill:#FFF;color:#FFF}.page-error{background:#48406B;max-width:820px;margin:0 auto;min-height:600px;min-height:100vh;display:-ms-flexbox;display:flex;-ms-flex-align:center;align-items:center;-ms-flex-pack:center;justify-content:center}.wf-loading .page-error{opacity:0}.page-error .section{padding:5%}.page-error .section-header{animation:slide-in-from-bottom .4s ease-out;position:relative;z-index:1;margin:auto}.page-error,.page-error .section-description,.page-error .section-title{color:#FFF}.page-error .section-description{margin-bottom:44px}.page-error .section-actions{margin-top:66px}.page-error .btn{margin-bottom:22px;min-width:130px}.error-code{font-family:Menlo,Monaco,Consolas,"Courier New",monospace;color:rgba(255,255,255,.5);background:rgba(255,255,255,.05);padding:1% 2%}.content-particles{position:relative}#particles-js{position:absolute;left:0;top:0;width:100%;height:100%;z-index:0;background:#48406B}</style> <script>WebFontConfig = {
+                    google: {
+                      families: ['Source Sans Pro:400,600']
+                    },
+                    timeout: 3000
+                  };
+
+                  (function(d) {
+                    var wf = d.createElement('script'), s = d.scripts[0];
+                    wf.src = 'https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js';
+                    wf.async = true;
+                    s.parentNode.insertBefore(wf, s);
+                  })(document);</script> <meta name="robots" content="noindex"> </head> <body class="page-error"> <article class="content-particles section"> <header class="section-header"> <svg class="logo logo-white" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="542px" height="99px" viewbox="0 0 542 99"> <path d="M508.3 16.2v30.1c0 4.7-1.2 8.4-3.6 11-2.4 2.6-5.6 3.8-9.5 3.8-3.4 0-6.3-1.2-8.5-3.6-2.3-2.4-3.4-5.4-3.4-9V16.2h-12.5v32.3c0 7.3 2.1 13.5 6.3 17.9 4.2 4.4 9.4 6.6 16 6.6 1.9 0 3.9-.3 5.7-.7 1.9-.5 3.4-1.1 4.6-1.7 1.2-.6 2.4-1.3 3.4-2.1.3-.2.8-.6 1-.9l.4-.5V72h12.4V16.2h-12.3zM36.5 60.9c-13.4 0-24.2-10.9-24.2-24.2 0-13.4 10.9-24.2 24.2-24.2 8 0 15.1 3.9 19.5 10l10.7-6.1C60.1 6.7 49 .3 36.5.3 16.4.3 0 16.7 0 36.8s16.4 36.5 36.5 36.5c12.6 0 23.7-6.4 30.3-16.1l-10.7-6.1c-4.5 5.9-11.6 9.8-19.6 9.8zM529.3.9h12.3v71.3h-12.3zM324.2.9l-20.1 34.2L284 .9h-15.8v71.3h12.3v-53l19.2 32.7h8.8l19.4-33v53.3h12.3l.1-71.3zm-80.6 27.6h16.5V16.2h-16.5V1h-12.3v50.1c0 12.1 5.5 21 20.8 21h8V59.8h-6.8c-8.7 0-9.7-4.3-9.7-8.6V28.5zm-59 16.3V16.3h-12.3v5.1c-4.6-3.2-10.2-5.1-16.2-5.1-15.7 0-28.6 12.8-28.6 28.6 0 15.7 12.8 28.6 28.6 28.6 6 0 11.6-1.9 16.2-5.1v3.9h12.3V44.8zm-28.5 16c-8.9 0-16.1-7.2-16.1-16.1 0-8.9 7.2-16.1 16.1-16.1 8.9 0 16.1 7.2 16.1 16.1-.1 8.9-7.3 16.1-16.1 16.1zm66.3-44.6c-2.4 0-10.1.2-17 4.5v-4.5h-12.3v55.9h12.3V41.7c0-3.5.8-6.2 2.4-8.1 4.2-5 12.3-5.3 12.8-5.3.6 0 1.4-.1 2.2-.1h3.2V16.3h-2.2c-.2-.1-1.3-.1-1.4-.1zM374 73.3c-15.7 0-28.5-12.8-28.5-28.5s12.8-28.5 28.5-28.5 28.5 12.8 28.5 28.5-12.8 28.5-28.5 28.5zm0-44.5c-8.8 0-16 7.2-16 16s7.2 16 16 16 16-7.2 16-16c0-8.9-7.2-16-16-16zm76.7-12.6v5.1c-4.6-3.2-10.1-5-16.1-5-15.7 0-28.5 12.8-28.5 28.5s12.8 28.5 28.5 28.5c6 0 11.5-1.9 16.1-5v1.1c0 .5-.1 1.1-.1 1.1-.6 4.2-2.6 8-5 10.7-3.1 3-6.9 4.3-11.3 4.4h-.3c-6.3-.2-11.9-3.1-15.4-7.6l-8.4 8.9c5 6.9 14.1 11.4 24.4 11.2 7.9 0 14.7-2.9 20.2-8.6 5.1-5.3 7.8-11.8 8.1-19.4 0 0 .1-.9.1-2V16.2h-12.3zm-16.1 44.6c-8.8 0-16-7.2-16-16s7.2-16 16-16 16 7.2 16 16-7.2 16-16 16zM95.7 28.6h2.4c-.4 0-.8-.1-1.2-.1-.5 0-.8 0-1.2.1z M121.6 40c0-14.6-10.1-23.8-23.8-23.8-5 0-9.7 1.6-13.5 4.2V.9H72v71.2h12.3V43.2c0-4.7 1.1-8.3 3.3-10.9 2-2.3 4.7-3.6 8.1-3.8.4 0 .7-.1 1.1-.1.4 0 .8 0 1.2.1 3.3.2 6 1.5 8 3.8 2.1 2.5 3.2 6 3.3 10.3v29.5h12.3V40z"> </path></svg> <h1 class="section-title">Oops! That page doesn&#x27;t exist.</h1> <p class="section-description"> We're usually good at connecting the dots but we couldn't find this page. </p> <p class="section-description"> <span class="error-code">404 Not Found</span> </p> <p class="section-actions"> <a class="btn btn-bordered" href="/">Homepage</a> <a class="btn btn-bordered" href="mailto:support@chartmogul.com">Contact Support</a> </p> </header> </article> <div id="particles-js"></div> <script type="text/javascript">function hexToRgb(e){var a=/^#?([a-f\d])([a-f\d])([a-f\d])$/i;e=e.replace(a,function(e,a,t,i){return a+a+t+t+i+i});var t=/^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(e);return t?{r:parseInt(t[1],16),g:parseInt(t[2],16),b:parseInt(t[3],16)}:null}function clamp(e,a,t){return Math.min(Math.max(e,a),t)}function isInArray(e,a){return a.indexOf(e)>-1}var pJS=function(e,a){var t=document.querySelector("#"+e+" > .particles-js-canvas-el");this.pJS={canvas:{el:t,w:t.offsetWidth,h:t.offsetHeight},particles:{number:{value:400,density:{enable:!0,value_area:800}},color:{value:"#fff"},shape:{type:"circle",stroke:{width:0,color:"#ff0000"},polygon:{nb_sides:5},image:{src:"",width:100,height:100}},opacity:{value:1,random:!1,anim:{enable:!1,speed:2,opacity_min:0,sync:!1}},size:{value:20,random:!1,anim:{enable:!1,speed:20,size_min:0,sync:!1}},line_linked:{enable:!0,distance:100,color:"#fff",opacity:1,width:1},move:{enable:!0,speed:2,direction:"none",random:!1,straight:!1,out_mode:"out",bounce:!1,attract:{enable:!1,rotateX:3e3,rotateY:3e3}},array:[]},interactivity:{detect_on:"canvas",events:{onhover:{enable:!0,mode:"grab"},onclick:{enable:!0,mode:"push"},resize:!0},modes:{grab:{distance:100,line_linked:{opacity:1}},bubble:{distance:200,size:80,duration:.4},repulse:{distance:200,duration:.4},push:{particles_nb:4},remove:{particles_nb:2}},mouse:{}},retina_detect:!1,fn:{interact:{},modes:{},vendors:{}},tmp:{}};var i=this.pJS;a&&Object.deepExtend(i,a),i.tmp.obj={size_value:i.particles.size.value,size_anim_speed:i.particles.size.anim.speed,move_speed:i.particles.move.speed,line_linked_distance:i.particles.line_linked.distance,line_linked_width:i.particles.line_linked.width,mode_grab_distance:i.interactivity.modes.grab.distance,mode_bubble_distance:i.interactivity.modes.bubble.distance,mode_bubble_size:i.interactivity.modes.bubble.size,mode_repulse_distance:i.interactivity.modes.repulse.distance},i.fn.retinaInit=function(){i.retina_detect&&window.devicePixelRatio>1?(i.canvas.pxratio=window.devicePixelRatio,i.tmp.retina=!0):(i.canvas.pxratio=1,i.tmp.retina=!1),i.canvas.w=i.canvas.el.offsetWidth*i.canvas.pxratio,i.canvas.h=i.canvas.el.offsetHeight*i.canvas.pxratio,i.particles.size.value=i.tmp.obj.size_value*i.canvas.pxratio,i.particles.size.anim.speed=i.tmp.obj.size_anim_speed*i.canvas.pxratio,i.particles.move.speed=i.tmp.obj.move_speed*i.canvas.pxratio,i.particles.line_linked.distance=i.tmp.obj.line_linked_distance*i.canvas.pxratio,i.interactivity.modes.grab.distance=i.tmp.obj.mode_grab_distance*i.canvas.pxratio,i.interactivity.modes.bubble.distance=i.tmp.obj.mode_bubble_distance*i.canvas.pxratio,i.particles.line_linked.width=i.tmp.obj.line_linked_width*i.canvas.pxratio,i.interactivity.modes.bubble.size=i.tmp.obj.mode_bubble_size*i.canvas.pxratio,i.interactivity.modes.repulse.distance=i.tmp.obj.mode_repulse_distance*i.canvas.pxratio},i.fn.canvasInit=function(){i.canvas.ctx=i.canvas.el.getContext("2d")},i.fn.canvasSize=function(){i.canvas.el.width=i.canvas.w,i.canvas.el.height=i.canvas.h,i&&i.interactivity.events.resize&&window.addEventListener("resize",function(){i.canvas.w=i.canvas.el.offsetWidth,i.canvas.h=i.canvas.el.offsetHeight,i.tmp.retina&&(i.canvas.w*=i.canvas.pxratio,i.canvas.h*=i.canvas.pxratio),i.canvas.el.width=i.canvas.w,i.canvas.el.height=i.canvas.h,i.particles.move.enable||(i.fn.particlesEmpty(),i.fn.particlesCreate(),i.fn.particlesDraw(),i.fn.vendors.densityAutoParticles()),i.fn.vendors.densityAutoParticles()})},i.fn.canvasPaint=function(){i.canvas.ctx.fillRect(0,0,i.canvas.w,i.canvas.h)},i.fn.canvasClear=function(){i.canvas.ctx.clearRect(0,0,i.canvas.w,i.canvas.h)},i.fn.particle=function(e,a,t){if(this.radius=(i.particles.size.random?Math.random():1)*i.particles.size.value,i.particles.size.anim.enable&&(this.size_status=!1,this.vs=i.particles.size.anim.speed/100,i.particles.size.anim.sync||(this.vs=this.vs*Math.random())),this.x=t?t.x:Math.random()*i.canvas.w,this.y=t?t.y:Math.random()*i.canvas.h,this.x>i.canvas.w-2*this.radius?this.x=this.x-this.radius:this.x<2*this.radius&&(this.x=this.x+this.radius),this.y>i.canvas.h-2*this.radius?this.y=this.y-this.radius:this.y<2*this.radius&&(this.y=this.y+this.radius),i.particles.move.bounce&&i.fn.vendors.checkOverlap(this,t),this.color={},"object"==typeof e.value)if(e.value instanceof Array){var n=e.value[Math.floor(Math.random()*i.particles.color.value.length)];this.color.rgb=hexToRgb(n)}else void 0!=e.value.r&&void 0!=e.value.g&&void 0!=e.value.b&&(this.color.rgb={r:e.value.r,g:e.value.g,b:e.value.b}),void 0!=e.value.h&&void 0!=e.value.s&&void 0!=e.value.l&&(this.color.hsl={h:e.value.h,s:e.value.s,l:e.value.l});else"random"==e.value?this.color.rgb={r:Math.floor(256*Math.random())+0,g:Math.floor(256*Math.random())+0,b:Math.floor(256*Math.random())+0}:"string"==typeof e.value&&(this.color=e,this.color.rgb=hexToRgb(this.color.value));this.opacity=(i.particles.opacity.random?Math.random():1)*i.particles.opacity.value,i.particles.opacity.anim.enable&&(this.opacity_status=!1,this.vo=i.particles.opacity.anim.speed/100,i.particles.opacity.anim.sync||(this.vo=this.vo*Math.random()));var s={};switch(i.particles.move.direction){case"top":s={x:0,y:-1};break;case"top-right":s={x:.5,y:-.5};break;case"right":s={x:1,y:-0};break;case"bottom-right":s={x:.5,y:.5};break;case"bottom":s={x:0,y:1};break;case"bottom-left":s={x:-.5,y:1};break;case"left":s={x:-1,y:0};break;case"top-left":s={x:-.5,y:-.5};break;default:s={x:0,y:0}}i.particles.move.straight?(this.vx=s.x,this.vy=s.y,i.particles.move.random&&(this.vx=this.vx*Math.random(),this.vy=this.vy*Math.random())):(this.vx=s.x+Math.random()-.5,this.vy=s.y+Math.random()-.5),this.vx_i=this.vx,this.vy_i=this.vy;var r=i.particles.shape.type;if("object"==typeof r){if(r instanceof Array){var c=r[Math.floor(Math.random()*r.length)];this.shape=c}}else this.shape=r;if("image"==this.shape){var o=i.particles.shape;this.img={src:o.image.src,ratio:o.image.width/o.image.height},this.img.ratio||(this.img.ratio=1),"svg"==i.tmp.img_type&&void 0!=i.tmp.source_svg&&(i.fn.vendors.createSvgImg(this),i.tmp.pushing&&(this.img.loaded=!1))}},i.fn.particle.prototype.draw=function(){function e(){i.canvas.ctx.drawImage(r,a.x-t,a.y-t,2*t,2*t/a.img.ratio)}var a=this;if(void 0!=a.radius_bubble)var t=a.radius_bubble;else var t=a.radius;if(void 0!=a.opacity_bubble)var n=a.opacity_bubble;else var n=a.opacity;if(a.color.rgb)var s="rgba("+a.color.rgb.r+","+a.color.rgb.g+","+a.color.rgb.b+","+n+")";else var s="hsla("+a.color.hsl.h+","+a.color.hsl.s+"%,"+a.color.hsl.l+"%,"+n+")";switch(i.canvas.ctx.fillStyle=s,i.canvas.ctx.beginPath(),a.shape){case"circle":i.canvas.ctx.arc(a.x,a.y,t,0,2*Math.PI,!1);break;case"edge":i.canvas.ctx.rect(a.x-t,a.y-t,2*t,2*t);break;case"triangle":i.fn.vendors.drawShape(i.canvas.ctx,a.x-t,a.y+t/1.66,2*t,3,2);break;case"polygon":i.fn.vendors.drawShape(i.canvas.ctx,a.x-t/(i.particles.shape.polygon.nb_sides/3.5),a.y-t/.76,2.66*t/(i.particles.shape.polygon.nb_sides/3),i.particles.shape.polygon.nb_sides,1);break;case"star":i.fn.vendors.drawShape(i.canvas.ctx,a.x-2*t/(i.particles.shape.polygon.nb_sides/4),a.y-t/1.52,2*t*2.66/(i.particles.shape.polygon.nb_sides/3),i.particles.shape.polygon.nb_sides,2);break;case"image":if("svg"==i.tmp.img_type)var r=a.img.obj;else var r=i.tmp.img_obj;r&&e()}i.canvas.ctx.closePath(),i.particles.shape.stroke.width>0&&(i.canvas.ctx.strokeStyle=i.particles.shape.stroke.color,i.canvas.ctx.lineWidth=i.particles.shape.stroke.width,i.canvas.ctx.stroke()),i.canvas.ctx.fill()},i.fn.particlesCreate=function(){for(var e=0;e<i.particles.number.value;e++)i.particles.array.push(new i.fn.particle(i.particles.color,i.particles.opacity.value))},i.fn.particlesUpdate=function(){for(var e=0;e<i.particles.array.length;e++){var a=i.particles.array[e];if(i.particles.move.enable){var t=i.particles.move.speed/2;a.x+=a.vx*t,a.y+=a.vy*t}if(i.particles.opacity.anim.enable&&(1==a.opacity_status?(a.opacity>=i.particles.opacity.value&&(a.opacity_status=!1),a.opacity+=a.vo):(a.opacity<=i.particles.opacity.anim.opacity_min&&(a.opacity_status=!0),a.opacity-=a.vo),a.opacity<0&&(a.opacity=0)),i.particles.size.anim.enable&&(1==a.size_status?(a.radius>=i.particles.size.value&&(a.size_status=!1),a.radius+=a.vs):(a.radius<=i.particles.size.anim.size_min&&(a.size_status=!0),a.radius-=a.vs),a.radius<0&&(a.radius=0)),"bounce"==i.particles.move.out_mode)var n={x_left:a.radius,x_right:i.canvas.w,y_top:a.radius,y_bottom:i.canvas.h};else var n={x_left:-a.radius,x_right:i.canvas.w+a.radius,y_top:-a.radius,y_bottom:i.canvas.h+a.radius};switch(a.x-a.radius>i.canvas.w?(a.x=n.x_left,a.y=Math.random()*i.canvas.h):a.x+a.radius<0&&(a.x=n.x_right,a.y=Math.random()*i.canvas.h),a.y-a.radius>i.canvas.h?(a.y=n.y_top,a.x=Math.random()*i.canvas.w):a.y+a.radius<0&&(a.y=n.y_bottom,a.x=Math.random()*i.canvas.w),i.particles.move.out_mode){case"bounce":a.x+a.radius>i.canvas.w?a.vx=-a.vx:a.x-a.radius<0&&(a.vx=-a.vx),a.y+a.radius>i.canvas.h?a.vy=-a.vy:a.y-a.radius<0&&(a.vy=-a.vy)}if(isInArray("grab",i.interactivity.events.onhover.mode)&&i.fn.modes.grabParticle(a),(isInArray("bubble",i.interactivity.events.onhover.mode)||isInArray("bubble",i.interactivity.events.onclick.mode))&&i.fn.modes.bubbleParticle(a),(isInArray("repulse",i.interactivity.events.onhover.mode)||isInArray("repulse",i.interactivity.events.onclick.mode))&&i.fn.modes.repulseParticle(a),i.particles.line_linked.enable||i.particles.move.attract.enable)for(var s=e+1;s<i.particles.array.length;s++){var r=i.particles.array[s];i.particles.line_linked.enable&&i.fn.interact.linkParticles(a,r),i.particles.move.attract.enable&&i.fn.interact.attractParticles(a,r),i.particles.move.bounce&&i.fn.interact.bounceParticles(a,r)}}},i.fn.particlesDraw=function(){i.canvas.ctx.clearRect(0,0,i.canvas.w,i.canvas.h),i.fn.particlesUpdate();for(var e=0;e<i.particles.array.length;e++){var a=i.particles.array[e];a.draw()}},i.fn.particlesEmpty=function(){i.particles.array=[]},i.fn.particlesRefresh=function(){cancelRequestAnimFrame(i.fn.checkAnimFrame),cancelRequestAnimFrame(i.fn.drawAnimFrame),i.tmp.source_svg=void 0,i.tmp.img_obj=void 0,i.tmp.count_svg=0,i.fn.particlesEmpty(),i.fn.canvasClear(),i.fn.vendors.start()},i.fn.interact.linkParticles=function(e,a){var t=e.x-a.x,n=e.y-a.y,s=Math.sqrt(t*t+n*n);if(s<=i.particles.line_linked.distance){var r=i.particles.line_linked.opacity-s/(1/i.particles.line_linked.opacity)/i.particles.line_linked.distance;if(r>0){var c=i.particles.line_linked.color_rgb_line;i.canvas.ctx.strokeStyle="rgba("+c.r+","+c.g+","+c.b+","+r+")",i.canvas.ctx.lineWidth=i.particles.line_linked.width,i.canvas.ctx.beginPath(),i.canvas.ctx.moveTo(e.x,e.y),i.canvas.ctx.lineTo(a.x,a.y),i.canvas.ctx.stroke(),i.canvas.ctx.closePath()}}},i.fn.interact.attractParticles=function(e,a){var t=e.x-a.x,n=e.y-a.y,s=Math.sqrt(t*t+n*n);if(s<=i.particles.line_linked.distance){var r=t/(1e3*i.particles.move.attract.rotateX),c=n/(1e3*i.particles.move.attract.rotateY);e.vx-=r,e.vy-=c,a.vx+=r,a.vy+=c}},i.fn.interact.bounceParticles=function(e,a){var t=e.x-a.x,i=e.y-a.y,n=Math.sqrt(t*t+i*i),s=e.radius+a.radius;n<=s&&(e.vx=-e.vx,e.vy=-e.vy,a.vx=-a.vx,a.vy=-a.vy)},i.fn.modes.pushParticles=function(e,a){i.tmp.pushing=!0;for(var t=0;t<e;t++)i.particles.array.push(new i.fn.particle(i.particles.color,i.particles.opacity.value,{x:a?a.pos_x:Math.random()*i.canvas.w,y:a?a.pos_y:Math.random()*i.canvas.h})),t==e-1&&(i.particles.move.enable||i.fn.particlesDraw(),i.tmp.pushing=!1)},i.fn.modes.removeParticles=function(e){i.particles.array.splice(0,e),i.particles.move.enable||i.fn.particlesDraw()},i.fn.modes.bubbleParticle=function(e){function a(){e.opacity_bubble=e.opacity,e.radius_bubble=e.radius}function t(a,t,n,s,c){if(a!=t)if(i.tmp.bubble_duration_end){if(void 0!=n){var o=s-p*(s-a)/i.interactivity.modes.bubble.duration,l=a-o;d=a+l,"size"==c&&(e.radius_bubble=d),"opacity"==c&&(e.opacity_bubble=d)}}else if(r<=i.interactivity.modes.bubble.distance){if(void 0!=n)var v=n;else var v=s;if(v!=a){var d=s-p*(s-a)/i.interactivity.modes.bubble.duration;"size"==c&&(e.radius_bubble=d),"opacity"==c&&(e.opacity_bubble=d)}}else"size"==c&&(e.radius_bubble=void 0),"opacity"==c&&(e.opacity_bubble=void 0)}if(i.interactivity.events.onhover.enable&&isInArray("bubble",i.interactivity.events.onhover.mode)){var n=e.x-i.interactivity.mouse.pos_x,s=e.y-i.interactivity.mouse.pos_y,r=Math.sqrt(n*n+s*s),c=1-r/i.interactivity.modes.bubble.distance;if(r<=i.interactivity.modes.bubble.distance){if(c>=0&&"mousemove"==i.interactivity.status){if(i.interactivity.modes.bubble.size!=i.particles.size.value)if(i.interactivity.modes.bubble.size>i.particles.size.value){var o=e.radius+i.interactivity.modes.bubble.size*c;o>=0&&(e.radius_bubble=o)}else{var l=e.radius-i.interactivity.modes.bubble.size,o=e.radius-l*c;o>0?e.radius_bubble=o:e.radius_bubble=0}if(i.interactivity.modes.bubble.opacity!=i.particles.opacity.value)if(i.interactivity.modes.bubble.opacity>i.particles.opacity.value){var v=i.interactivity.modes.bubble.opacity*c;v>e.opacity&&v<=i.interactivity.modes.bubble.opacity&&(e.opacity_bubble=v)}else{var v=e.opacity-(i.particles.opacity.value-i.interactivity.modes.bubble.opacity)*c;v<e.opacity&&v>=i.interactivity.modes.bubble.opacity&&(e.opacity_bubble=v)}}}else a();"mouseleave"==i.interactivity.status&&a()}else if(i.interactivity.events.onclick.enable&&isInArray("bubble",i.interactivity.events.onclick.mode)){if(i.tmp.bubble_clicking){var n=e.x-i.interactivity.mouse.click_pos_x,s=e.y-i.interactivity.mouse.click_pos_y,r=Math.sqrt(n*n+s*s),p=((new Date).getTime()-i.interactivity.mouse.click_time)/1e3;p>i.interactivity.modes.bubble.duration&&(i.tmp.bubble_duration_end=!0),p>2*i.interactivity.modes.bubble.duration&&(i.tmp.bubble_clicking=!1,i.tmp.bubble_duration_end=!1)}i.tmp.bubble_clicking&&(t(i.interactivity.modes.bubble.size,i.particles.size.value,e.radius_bubble,e.radius,"size"),t(i.interactivity.modes.bubble.opacity,i.particles.opacity.value,e.opacity_bubble,e.opacity,"opacity"))}},i.fn.modes.repulseParticle=function(e){function a(){var a=Math.atan2(d,p);if(e.vx=u*Math.cos(a),e.vy=u*Math.sin(a),"bounce"==i.particles.move.out_mode){var t={x:e.x+e.vx,y:e.y+e.vy};t.x+e.radius>i.canvas.w?e.vx=-e.vx:t.x-e.radius<0&&(e.vx=-e.vx),t.y+e.radius>i.canvas.h?e.vy=-e.vy:t.y-e.radius<0&&(e.vy=-e.vy)}}if(i.interactivity.events.onhover.enable&&isInArray("repulse",i.interactivity.events.onhover.mode)&&"mousemove"==i.interactivity.status){var t=e.x-i.interactivity.mouse.pos_x,n=e.y-i.interactivity.mouse.pos_y,s=Math.sqrt(t*t+n*n),r={x:t/s,y:n/s},c=i.interactivity.modes.repulse.distance,o=100,l=clamp(1/c*(-1*Math.pow(s/c,2)+1)*c*o,0,50),v={x:e.x+r.x*l,y:e.y+r.y*l};"bounce"==i.particles.move.out_mode?(v.x-e.radius>0&&v.x+e.radius<i.canvas.w&&(e.x=v.x),v.y-e.radius>0&&v.y+e.radius<i.canvas.h&&(e.y=v.y)):(e.x=v.x,e.y=v.y)}else if(i.interactivity.events.onclick.enable&&isInArray("repulse",i.interactivity.events.onclick.mode))if(i.tmp.repulse_finish||(i.tmp.repulse_count++,i.tmp.repulse_count==i.particles.array.length&&(i.tmp.repulse_finish=!0)),i.tmp.repulse_clicking){var c=Math.pow(i.interactivity.modes.repulse.distance/6,3),p=i.interactivity.mouse.click_pos_x-e.x,d=i.interactivity.mouse.click_pos_y-e.y,m=p*p+d*d,u=-c/m*1;m<=c&&a()}else 0==i.tmp.repulse_clicking&&(e.vx=e.vx_i,e.vy=e.vy_i)},i.fn.modes.grabParticle=function(e){if(i.interactivity.events.onhover.enable&&"mousemove"==i.interactivity.status){var a=e.x-i.interactivity.mouse.pos_x,t=e.y-i.interactivity.mouse.pos_y,n=Math.sqrt(a*a+t*t);if(n<=i.interactivity.modes.grab.distance){var s=i.interactivity.modes.grab.line_linked.opacity-n/(1/i.interactivity.modes.grab.line_linked.opacity)/i.interactivity.modes.grab.distance;if(s>0){var r=i.particles.line_linked.color_rgb_line;i.canvas.ctx.strokeStyle="rgba("+r.r+","+r.g+","+r.b+","+s+")",i.canvas.ctx.lineWidth=i.particles.line_linked.width,i.canvas.ctx.beginPath(),i.canvas.ctx.moveTo(e.x,e.y),i.canvas.ctx.lineTo(i.interactivity.mouse.pos_x,i.interactivity.mouse.pos_y),i.canvas.ctx.stroke(),i.canvas.ctx.closePath()}}}},i.fn.vendors.eventsListeners=function(){"window"==i.interactivity.detect_on?i.interactivity.el=window:i.interactivity.el=i.canvas.el,(i.interactivity.events.onhover.enable||i.interactivity.events.onclick.enable)&&(i.interactivity.el.addEventListener("mousemove",function(e){if(i.interactivity.el==window)var a=e.clientX,t=e.clientY;else var a=e.offsetX||e.clientX,t=e.offsetY||e.clientY;i.interactivity.mouse.pos_x=a,i.interactivity.mouse.pos_y=t,i.tmp.retina&&(i.interactivity.mouse.pos_x*=i.canvas.pxratio,i.interactivity.mouse.pos_y*=i.canvas.pxratio),i.interactivity.status="mousemove"}),i.interactivity.el.addEventListener("mouseleave",function(e){i.interactivity.mouse.pos_x=null,i.interactivity.mouse.pos_y=null,i.interactivity.status="mouseleave"})),i.interactivity.events.onclick.enable&&i.interactivity.el.addEventListener("click",function(){if(i.interactivity.mouse.click_pos_x=i.interactivity.mouse.pos_x,i.interactivity.mouse.click_pos_y=i.interactivity.mouse.pos_y,i.interactivity.mouse.click_time=(new Date).getTime(),i.interactivity.events.onclick.enable)switch(i.interactivity.events.onclick.mode){case"push":i.particles.move.enable?i.fn.modes.pushParticles(i.interactivity.modes.push.particles_nb,i.interactivity.mouse):1==i.interactivity.modes.push.particles_nb?i.fn.modes.pushParticles(i.interactivity.modes.push.particles_nb,i.interactivity.mouse):i.interactivity.modes.push.particles_nb>1&&i.fn.modes.pushParticles(i.interactivity.modes.push.particles_nb);break;case"remove":i.fn.modes.removeParticles(i.interactivity.modes.remove.particles_nb);break;case"bubble":i.tmp.bubble_clicking=!0;break;case"repulse":i.tmp.repulse_clicking=!0,i.tmp.repulse_count=0,i.tmp.repulse_finish=!1,setTimeout(function(){i.tmp.repulse_clicking=!1},1e3*i.interactivity.modes.repulse.duration)}})},i.fn.vendors.densityAutoParticles=function(){if(i.particles.number.density.enable){var e=i.canvas.el.width*i.canvas.el.height/1e3;i.tmp.retina&&(e/=2*i.canvas.pxratio);var a=e*i.particles.number.value/i.particles.number.density.value_area,t=i.particles.array.length-a;t<0?i.fn.modes.pushParticles(Math.abs(t)):i.fn.modes.removeParticles(t)}},i.fn.vendors.checkOverlap=function(e,a){for(var t=0;t<i.particles.array.length;t++){var n=i.particles.array[t],s=e.x-n.x,r=e.y-n.y,c=Math.sqrt(s*s+r*r);c<=e.radius+n.radius&&(e.x=a?a.x:Math.random()*i.canvas.w,e.y=a?a.y:Math.random()*i.canvas.h,i.fn.vendors.checkOverlap(e))}},i.fn.vendors.createSvgImg=function(e){var a=i.tmp.source_svg,t=/#([0-9A-F]{3,6})/gi,n=a.replace(t,function(a,t,i,n){if(e.color.rgb)var s="rgba("+e.color.rgb.r+","+e.color.rgb.g+","+e.color.rgb.b+","+e.opacity+")";else var s="hsla("+e.color.hsl.h+","+e.color.hsl.s+"%,"+e.color.hsl.l+"%,"+e.opacity+")";return s}),s=new Blob([n],{type:"image/svg+xml;charset=utf-8"}),r=window.URL||window.webkitURL||window,c=r.createObjectURL(s),o=new Image;o.addEventListener("load",function(){e.img.obj=o,e.img.loaded=!0,r.revokeObjectURL(c),i.tmp.count_svg++}),o.src=c},i.fn.vendors.destroypJS=function(){cancelAnimationFrame(i.fn.drawAnimFrame),t.remove(),pJSDom=null},i.fn.vendors.drawShape=function(e,a,t,i,n,s){var r=n*s,c=n/s,o=180*(c-2)/c,l=Math.PI-Math.PI*o/180;e.save(),e.beginPath(),e.translate(a,t),e.moveTo(0,0);for(var v=0;v<r;v++)e.lineTo(i,0),e.translate(i,0),e.rotate(l);e.fill(),e.restore()},i.fn.vendors.exportImg=function(){window.open(i.canvas.el.toDataURL("image/png"),"_blank")},i.fn.vendors.loadImg=function(e){if(i.tmp.img_error=void 0,""!=i.particles.shape.image.src)if("svg"==e){var a=new XMLHttpRequest;a.open("GET",i.particles.shape.image.src),a.onreadystatechange=function(e){4==a.readyState&&(200==a.status?(i.tmp.source_svg=e.currentTarget.response,i.fn.vendors.checkBeforeDraw()):(console.log("Error pJS - Image not found"),i.tmp.img_error=!0))},a.send()}else{var t=new Image;t.addEventListener("load",function(){i.tmp.img_obj=t,i.fn.vendors.checkBeforeDraw()}),t.src=i.particles.shape.image.src}else console.log("Error pJS - No image.src"),i.tmp.img_error=!0},i.fn.vendors.draw=function(){"image"==i.particles.shape.type?"svg"==i.tmp.img_type?i.tmp.count_svg>=i.particles.number.value?(i.fn.particlesDraw(),i.particles.move.enable?i.fn.drawAnimFrame=requestAnimFrame(i.fn.vendors.draw):cancelRequestAnimFrame(i.fn.drawAnimFrame)):i.tmp.img_error||(i.fn.drawAnimFrame=requestAnimFrame(i.fn.vendors.draw)):void 0!=i.tmp.img_obj?(i.fn.particlesDraw(),i.particles.move.enable?i.fn.drawAnimFrame=requestAnimFrame(i.fn.vendors.draw):cancelRequestAnimFrame(i.fn.drawAnimFrame)):i.tmp.img_error||(i.fn.drawAnimFrame=requestAnimFrame(i.fn.vendors.draw)):(i.fn.particlesDraw(),i.particles.move.enable?i.fn.drawAnimFrame=requestAnimFrame(i.fn.vendors.draw):cancelRequestAnimFrame(i.fn.drawAnimFrame))},i.fn.vendors.checkBeforeDraw=function(){"image"==i.particles.shape.type?"svg"==i.tmp.img_type&&void 0==i.tmp.source_svg?i.tmp.checkAnimFrame=requestAnimFrame(check):(cancelRequestAnimFrame(i.tmp.checkAnimFrame),i.tmp.img_error||(i.fn.vendors.init(),i.fn.vendors.draw())):(i.fn.vendors.init(),i.fn.vendors.draw())},i.fn.vendors.init=function(){i.fn.retinaInit(),i.fn.canvasInit(),i.fn.canvasSize(),i.fn.canvasPaint(),i.fn.particlesCreate(),i.fn.vendors.densityAutoParticles(),i.particles.line_linked.color_rgb_line=hexToRgb(i.particles.line_linked.color)},i.fn.vendors.start=function(){isInArray("image",i.particles.shape.type)?(i.tmp.img_type=i.particles.shape.image.src.substr(i.particles.shape.image.src.length-3),i.fn.vendors.loadImg(i.tmp.img_type)):i.fn.vendors.checkBeforeDraw()},i.fn.vendors.eventsListeners(),i.fn.vendors.start()};Object.deepExtend=function(e,a){for(var t in a)a[t]&&a[t].constructor&&a[t].constructor===Object?(e[t]=e[t]||{},arguments.callee(e[t],a[t])):e[t]=a[t];return e},window.requestAnimFrame=function(){return window.requestAnimationFrame||window.webkitRequestAnimationFrame||window.mozRequestAnimationFrame||window.oRequestAnimationFrame||window.msRequestAnimationFrame||function(e){window.setTimeout(e,1e3/60)}}(),window.cancelRequestAnimFrame=function(){return window.cancelAnimationFrame||window.webkitCancelRequestAnimationFrame||window.mozCancelRequestAnimationFrame||window.oCancelRequestAnimationFrame||window.msCancelRequestAnimationFrame||clearTimeout}(),window.pJSDom=[],window.particlesJS=function(e,a){"string"!=typeof e&&(a=e,e="particles-js"),e||(e="particles-js");var t=document.getElementById(e),i="particles-js-canvas-el",n=t.getElementsByClassName(i);if(n.length)for(;n.length>0;)t.removeChild(n[0]);var s=document.createElement("canvas");s.className=i,s.style.width="100%",s.style.height="100%";var r=document.getElementById(e).appendChild(s);null!=r&&pJSDom.push(new pJS(e,a))},window.particlesJS.load=function(e,a,t){var i=new XMLHttpRequest;i.open("GET",a),i.onreadystatechange=function(a){if(4==i.readyState)if(200==i.status){var n=JSON.parse(a.currentTarget.response);window.particlesJS(e,n),t&&t()}else console.log("Error pJS - XMLHttpRequest status: "+i.status),console.log("Error pJS - File config not found")},i.send()},particlesJS("particles-js",{particles:{number:{value:120,density:{enable:!0,value_area:962.0443442314919}},color:{value:"#EF4F51"},shape:{type:"circle",stroke:{width:0,color:"#EF4F51"},polygon:{nb_sides:5}},opacity:{value:.2,random:!1,anim:{enable:!1,speed:1,opacity_min:.1,sync:!1}},size:{value:6,random:!0,anim:{enable:!1,speed:40,size_min:.1,sync:!1}},line_linked:{enable:!0,distance:208.4429412501566,color:"#7ACCC9",opacity:.4,width:1},move:{enable:!0,speed:2,direction:"none",random:!1,straight:!1,out_mode:"bounce",bounce:!1,attract:{enable:!1,rotateX:600,rotateY:1200}}},interactivity:{detect_on:"canvas",events:{onhover:{enable:!0,mode:"repulse"},onclick:{enable:!0,mode:"push"},resize:!0},modes:{grab:{distance:400,line_linked:{opacity:1}},bubble:{distance:400,size:40,duration:2,opacity:8,speed:3},repulse:{distance:56.84557797233854,duration:.4},push:{particles_nb:4},remove:{particles_nb:2}}},retina_detect:!0});</script> </body> </html>
+    http_version: 
+  recorded_at: Wed, 12 Feb 2020 16:51:00 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/retrieves_existing_plan_group_by_uuid.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/retrieves_existing_plan_group_by_uuid.yml
@@ -1,0 +1,251 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/data_sources
+    body:
+      encoding: UTF-8
+      string: '{"name":"Data Source #1"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 201
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 17:14:53 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '152'
+      connection:
+      - close
+      status:
+      - 201 Created
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"uuid":"ds_829c448a-5404-11ea-ab18-db11706d03de","name":"Data Source
+        #1","system":"Import API","created_at":"2020-02-20T17:14:53.542Z","status":"idle"}'
+    http_version:
+  recorded_at: Thu, 20 Feb 2020 17:14:53 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plans
+    body:
+      encoding: UTF-8
+      string: '{"name":"A Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_829c448a-5404-11ea-ab18-db11706d03de"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 201
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 17:14:54 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 201 Created
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"902ad62e9093abc28f236ceffb652454"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 5e5445aa-cfaf-4b3f-b609-c06bdcdabf07
+      x-runtime:
+      - '0.105219'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"6f5f2e80-3632-0138-ca32-42eead14b4ad","name":"A Test
+        Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_829c448a-5404-11ea-ab18-db11706d03de","uuid":"pl_6f5f2e80-3632-0138-ca32-42eead14b4ad"}'
+    http_version:
+  recorded_at: Thu, 20 Feb 2020 17:14:54 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plans
+    body:
+      encoding: UTF-8
+      string: '{"name":"A another Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_829c448a-5404-11ea-ab18-db11706d03de"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 201
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 17:14:54 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 201 Created
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"7b328c6d0ef318c67e036f598a2b2554"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 0143f23d-cf20-4172-8821-e663d34e3ea3
+      x-runtime:
+      - '0.171744'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"6f8e4b20-3632-0138-f01e-62b37fb4c770","name":"A another
+        Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_829c448a-5404-11ea-ab18-db11706d03de","uuid":"pl_6f8e4b20-3632-0138-f01e-62b37fb4c770"}'
+    http_version:
+  recorded_at: Thu, 20 Feb 2020 17:14:54 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plan_groups
+    body:
+      encoding: UTF-8
+      string: '{"name":"My plan group","plans":["pl_6f5f2e80-3632-0138-ca32-42eead14b4ad","pl_6f8e4b20-3632-0138-f01e-62b37fb4c770"]}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 17:14:54 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"8d079567f75302f08e366740c2dd92f4"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - cc79c4d5-9a2a-4bda-ad92-1a935efe7938
+      x-runtime:
+      - '0.073698'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"My plan group","uuid":"plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab","plans_count":2}'
+    http_version:
+  recorded_at: Thu, 20 Feb 2020 17:14:54 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/plan_groups/plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 17:14:54 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"8d079567f75302f08e366740c2dd92f4"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 8174e86d-fbe3-4deb-89bb-74267418428d
+      x-runtime:
+      - '0.069583'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"My plan group","uuid":"plg_b53fdbfc-c5eb-4a61-a589-85146cf8d0ab","plans_count":2}'
+    http_version:
+  recorded_at: Thu, 20 Feb 2020 17:14:54 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/returns_an_array_of_plan_groups.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/returns_an_array_of_plan_groups.yml
@@ -1,0 +1,357 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/data_sources
+    body:
+      encoding: UTF-8
+      string: '{"name":"Data Source #1"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 201
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 10:42:18 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '152'
+      connection:
+      - close
+      status:
+      - 201 Created
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"uuid":"ds_aa7503e8-53cd-11ea-aae9-e734eaddcf1d","name":"Data Source
+        #1","system":"Import API","created_at":"2020-02-20T10:42:17.984Z","status":"idle"}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 10:42:18 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plans
+    body:
+      encoding: UTF-8
+      string: '{"name":"A Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_aa7503e8-53cd-11ea-aae9-e734eaddcf1d"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 201
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 10:42:18 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 201 Created
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"054766b8d387cec3ef504b2ff6a997b6"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 1e8faf16-56cb-4e75-9dac-b456653676e7
+      x-runtime:
+      - '0.194130'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"97490c90-35fb-0138-f016-62b37fb4c770","name":"A Test
+        Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_aa7503e8-53cd-11ea-aae9-e734eaddcf1d","uuid":"pl_97490c90-35fb-0138-f016-62b37fb4c770"}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 10:42:18 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plans
+    body:
+      encoding: UTF-8
+      string: '{"name":"A another Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_aa7503e8-53cd-11ea-aae9-e734eaddcf1d"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 201
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 10:42:19 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 201 Created
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"e4f2a6e82a1a1e8dbe25c9a0ab1c7707"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 6b6f5af3-5a77-4bbd-a6c1-23f9866f4677
+      x-runtime:
+      - '0.135728'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"9781a5d0-35fb-0138-3705-364318904ce3","name":"A another
+        Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_aa7503e8-53cd-11ea-aae9-e734eaddcf1d","uuid":"pl_9781a5d0-35fb-0138-3705-364318904ce3"}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 10:42:19 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plan_groups
+    body:
+      encoding: UTF-8
+      string: '{"name":"My plan group","plans":["pl_97490c90-35fb-0138-f016-62b37fb4c770","pl_9781a5d0-35fb-0138-3705-364318904ce3"]}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 10:42:19 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"53b233ebc77584ca11ba27522debed3a"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 36def44d-7c26-4446-9609-a48836ad5195
+      x-runtime:
+      - '0.113148'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"My plan group","uuid":"plg_3c2b0732-cff0-437f-9f8d-a575ccc8b7e9","plans_count":2}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 10:42:19 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plans
+    body:
+      encoding: UTF-8
+      string: '{"name":"A another Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_aa7503e8-53cd-11ea-aae9-e734eaddcf1d"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 201
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 10:42:19 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 201 Created
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"6903fe5a1ce6d99a70cde43e818d327a"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - bb1fe96f-6288-4b86-9a3e-2122666c9573
+      x-runtime:
+      - '0.146997'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"97e04cd0-35fb-0138-b58f-4e501129bd4a","name":"A another
+        Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_aa7503e8-53cd-11ea-aae9-e734eaddcf1d","uuid":"pl_97e04cd0-35fb-0138-b58f-4e501129bd4a"}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 10:42:19 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plan_groups
+    body:
+      encoding: UTF-8
+      string: '{"name":"My second plan group","plans":["pl_9781a5d0-35fb-0138-3705-364318904ce3","pl_97e04cd0-35fb-0138-b58f-4e501129bd4a"]}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 10:42:19 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"72125c9c54ed510796063eb63630e929"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - fa72a972-80bf-411a-bedf-75a4790cb505
+      x-runtime:
+      - '0.071034'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"My second plan group","uuid":"plg_1d960363-a335-4e21-90cd-f3686c143453","plans_count":2}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 10:42:19 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/plan_groups
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 10:42:20 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"8f193c3d2a8b1865b2e2ca5f425c11f8"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - b87e4ab8-ef16-476a-accf-1caa595abcb1
+      x-runtime:
+      - '0.117165'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"plan_groups":[{"name":"My plan group","uuid":"plg_3c2b0732-cff0-437f-9f8d-a575ccc8b7e9","plans_count":2},{"name":"My
+        second plan group","uuid":"plg_1d960363-a335-4e21-90cd-f3686c143453","plans_count":2}],"current_page":1,"total_pages":1}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 10:42:20 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/updates_existing_plan_group_name.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/updates_existing_plan_group_name.yml
@@ -1,0 +1,304 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/data_sources
+    body:
+      encoding: UTF-8
+      string: '{"name":"Data Source #1"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 201
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 17:13:29 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '152'
+      connection:
+      - close
+      status:
+      - 201 Created
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"uuid":"ds_502f5a1e-5404-11ea-ab18-ffd72d6e41ca","name":"Data Source
+        #1","system":"Import API","created_at":"2020-02-20T17:13:28.947Z","status":"idle"}'
+    http_version:
+  recorded_at: Thu, 20 Feb 2020 17:13:29 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plans
+    body:
+      encoding: UTF-8
+      string: '{"name":"A Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_502f5a1e-5404-11ea-ab18-ffd72d6e41ca"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 201
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 17:13:29 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 201 Created
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"b1925828957c62f22be7e57b394db7be"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - a0de0538-ef46-410c-a782-59ffc8909ef4
+      x-runtime:
+      - '0.133357'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"3cf5d690-3632-0138-b59b-4e501129bd4a","name":"A Test
+        Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_502f5a1e-5404-11ea-ab18-ffd72d6e41ca","uuid":"pl_3cf5d690-3632-0138-b59b-4e501129bd4a"}'
+    http_version:
+  recorded_at: Thu, 20 Feb 2020 17:13:29 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plans
+    body:
+      encoding: UTF-8
+      string: '{"name":"A another Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_502f5a1e-5404-11ea-ab18-ffd72d6e41ca"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 201
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 17:13:29 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 201 Created
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"b23dd9ce0e237a70626d7d389a44fc7c"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 0accd7b9-9001-4b89-a38c-a52b60ffc09e
+      x-runtime:
+      - '0.203924'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"3d3199f0-3632-0138-f01d-62b37fb4c770","name":"A another
+        Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_502f5a1e-5404-11ea-ab18-ffd72d6e41ca","uuid":"pl_3d3199f0-3632-0138-f01d-62b37fb4c770"}'
+    http_version:
+  recorded_at: Thu, 20 Feb 2020 17:13:29 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plan_groups
+    body:
+      encoding: UTF-8
+      string: '{"name":"My plan group","plans":["pl_3cf5d690-3632-0138-b59b-4e501129bd4a","pl_3d3199f0-3632-0138-f01d-62b37fb4c770"]}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 17:13:30 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"b64c5d68668419bcbb91a96e0ed6c00d"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 2cf1076a-1c68-49f7-b7d9-38cb98ab84e8
+      x-runtime:
+      - '0.070373'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"My plan group","uuid":"plg_44f41eeb-f61a-4aef-b95d-f78841d61f1b","plans_count":2}'
+    http_version:
+  recorded_at: Thu, 20 Feb 2020 17:13:30 GMT
+- request:
+    method: patch
+    uri: https://api.chartmogul.com/v1/plan_groups/plg_44f41eeb-f61a-4aef-b95d-f78841d61f1b
+    body:
+      encoding: UTF-8
+      string: '{"name":"A new plan group_name"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 17:13:30 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"6396163c6308c50b2dca74e3cc508a5b"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 8aa04eab-de86-4946-8d43-759c08b7291e
+      x-runtime:
+      - '0.076873'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"A new plan group_name","uuid":"plg_44f41eeb-f61a-4aef-b95d-f78841d61f1b","plans_count":2}'
+    http_version:
+  recorded_at: Thu, 20 Feb 2020 17:13:30 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/plan_groups/plg_44f41eeb-f61a-4aef-b95d-f78841d61f1b
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 17:13:30 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"6396163c6308c50b2dca74e3cc508a5b"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - ff9effdc-277e-4672-9503-43397a999624
+      x-runtime:
+      - '0.031658'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"A new plan group_name","uuid":"plg_44f41eeb-f61a-4aef-b95d-f78841d61f1b","plans_count":2}'
+    http_version:
+  recorded_at: Thu, 20 Feb 2020 17:13:30 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/updates_existing_plan_group_plans.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/updates_existing_plan_group_plans.yml
@@ -1,0 +1,411 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/data_sources
+    body:
+      encoding: UTF-8
+      string: '{"name":"Data Source #1"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 201
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 10:57:21 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '152'
+      connection:
+      - close
+      status:
+      - 201 Created
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"uuid":"ds_c4fdc7a2-53cf-11ea-aae9-cba10afd2cab","name":"Data Source
+        #1","system":"Import API","created_at":"2020-02-20T10:57:21.537Z","status":"idle"}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 10:57:22 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plans
+    body:
+      encoding: UTF-8
+      string: '{"name":"A another Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_c4fdc7a2-53cf-11ea-aae9-cba10afd2cab"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 201
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 10:57:22 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 201 Created
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"680bf36b1c4f2dff6428304f51e2c5d1"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 98cf8d71-2a0a-464f-8580-4d7584f05c28
+      x-runtime:
+      - '0.093243'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"b1d2e190-35fd-0138-b593-4e501129bd4a","name":"A another
+        Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_c4fdc7a2-53cf-11ea-aae9-cba10afd2cab","uuid":"pl_b1d2e190-35fd-0138-b593-4e501129bd4a"}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 10:57:22 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plans
+    body:
+      encoding: UTF-8
+      string: '{"name":"A Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_c4fdc7a2-53cf-11ea-aae9-cba10afd2cab"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 201
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 10:57:22 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 201 Created
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"b8310c5c76d0a1261ae0e170774c8317"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - a350a73c-a056-4f06-9f9c-809439bf6019
+      x-runtime:
+      - '0.147289'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"b1fa8e50-35fd-0138-b594-4e501129bd4a","name":"A Test
+        Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_c4fdc7a2-53cf-11ea-aae9-cba10afd2cab","uuid":"pl_b1fa8e50-35fd-0138-b594-4e501129bd4a"}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 10:57:22 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plans
+    body:
+      encoding: UTF-8
+      string: '{"name":"A another Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_c4fdc7a2-53cf-11ea-aae9-cba10afd2cab"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 201
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 10:57:22 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 201 Created
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"f7b6f9160ce0ef3a1548ce6ce684d83e"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 251b2e7c-bbe3-4259-859d-39cbd6e29aa0
+      x-runtime:
+      - '0.133838'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"b225c9f0-35fd-0138-b595-4e501129bd4a","name":"A another
+        Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_c4fdc7a2-53cf-11ea-aae9-cba10afd2cab","uuid":"pl_b225c9f0-35fd-0138-b595-4e501129bd4a"}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 10:57:22 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plan_groups
+    body:
+      encoding: UTF-8
+      string: '{"name":"My plan group","plans":["pl_b1fa8e50-35fd-0138-b594-4e501129bd4a","pl_b225c9f0-35fd-0138-b595-4e501129bd4a"]}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 10:57:23 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"7c591e7d5ee581e4ae49ffccb4165863"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - aaf768b5-e7b3-4e8a-892b-4c4e313cc409
+      x-runtime:
+      - '0.077071'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"My plan group","uuid":"plg_de7adee5-7a1e-4e3f-ac11-978c9294427a","plans_count":2}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 10:57:23 GMT
+- request:
+    method: patch
+    uri: https://api.chartmogul.com/v1/plan_groups/plg_de7adee5-7a1e-4e3f-ac11-978c9294427a
+    body:
+      encoding: UTF-8
+      string: '{"name":"My plan group","plans_count":2,"plans":["pl_b1fa8e50-35fd-0138-b594-4e501129bd4a","pl_b225c9f0-35fd-0138-b595-4e501129bd4a","pl_b1d2e190-35fd-0138-b593-4e501129bd4a"]}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 10:57:23 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"5cd2492b2cccc2503702e906a10a0dab"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 7efb2bc8-85e8-45c9-aa26-0df590228126
+      x-runtime:
+      - '0.131806'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"My plan group","uuid":"plg_de7adee5-7a1e-4e3f-ac11-978c9294427a","plans_count":3}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 10:57:23 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/plan_groups/plg_de7adee5-7a1e-4e3f-ac11-978c9294427a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 10:57:23 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"5cd2492b2cccc2503702e906a10a0dab"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - fe9819d4-9413-4430-8648-298c8c24ab95
+      x-runtime:
+      - '0.043397'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"My plan group","uuid":"plg_de7adee5-7a1e-4e3f-ac11-978c9294427a","plans_count":3}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 10:57:23 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/plan_groups/plg_de7adee5-7a1e-4e3f-ac11-978c9294427a/plans
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic secret
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 10:57:23 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"9d72543d2f2e6ffba5e5b8db51920b40"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - f876000c-f4b2-4e85-b033-76bd3a44a4fb
+      x-runtime:
+      - '0.108157'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"plans":[{"name":"A another Test Plan","uuid":"pl_b1d2e190-35fd-0138-b593-4e501129bd4a","data_source_uuid":"ds_c4fdc7a2-53cf-11ea-aae9-cba10afd2cab","interval_count":1,"interval_unit":"month","external_id":"b1d2e190-35fd-0138-b593-4e501129bd4a"},{"name":"A
+        Test Plan","uuid":"pl_b1fa8e50-35fd-0138-b594-4e501129bd4a","data_source_uuid":"ds_c4fdc7a2-53cf-11ea-aae9-cba10afd2cab","interval_count":1,"interval_unit":"month","external_id":"b1fa8e50-35fd-0138-b594-4e501129bd4a"},{"name":"A
+        another Test Plan","uuid":"pl_b225c9f0-35fd-0138-b595-4e501129bd4a","data_source_uuid":"ds_c4fdc7a2-53cf-11ea-aae9-cba10afd2cab","interval_count":1,"interval_unit":"month","external_id":"b225c9f0-35fd-0138-b595-4e501129bd4a"}],"current_page":1,"total_pages":1}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 10:57:23 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/ChartMogul_PlanGroups_Plans/API_interactions/given_a_plan_group_uuid_returns_an_array_of_plans_in_the_plan_group.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_PlanGroups_Plans/API_interactions/given_a_plan_group_uuid_returns_an_array_of_plans_in_the_plan_group.yml
@@ -1,0 +1,252 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/data_sources
+    body:
+      encoding: UTF-8
+      string: '{"name":"Data Source #1"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic OGIzNjcyOWUzMmU1OWJiMTBlNjEwZWZiOWFhNjExZTA6Nzg0MWEyNWU4Y2VkMmZjOGRmYzFhZGU3YWM0ZmFjZTQ=
+  response:
+    status:
+      code: 201
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 17:20:15 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '152'
+      connection:
+      - close
+      status:
+      - 201 Created
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"uuid":"ds_424b9628-5405-11ea-ab18-e3a0f4f45097","name":"Data Source
+        #1","system":"Import API","created_at":"2020-02-20T17:20:15.102Z","status":"idle"}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 17:20:15 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plans
+    body:
+      encoding: UTF-8
+      string: '{"name":"A Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_424b9628-5405-11ea-ab18-e3a0f4f45097"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic OGIzNjcyOWUzMmU1OWJiMTBlNjEwZWZiOWFhNjExZTA6Nzg0MWEyNWU4Y2VkMmZjOGRmYzFhZGU3YWM0ZmFjZTQ=
+  response:
+    status:
+      code: 201
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 17:20:16 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 201 Created
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"de6a4357349f1e696cf670b8cb1d3a91"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 1d0fbf42-e22c-42ac-b068-3fc78e615d0b
+      x-runtime:
+      - '0.613620'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"2f7f4360-3633-0138-f01f-62b37fb4c770","name":"A Test
+        Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_424b9628-5405-11ea-ab18-e3a0f4f45097","uuid":"pl_2f7f4360-3633-0138-f01f-62b37fb4c770"}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 17:20:16 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plans
+    body:
+      encoding: UTF-8
+      string: '{"name":"A another Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_424b9628-5405-11ea-ab18-e3a0f4f45097"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic OGIzNjcyOWUzMmU1OWJiMTBlNjEwZWZiOWFhNjExZTA6Nzg0MWEyNWU4Y2VkMmZjOGRmYzFhZGU3YWM0ZmFjZTQ=
+  response:
+    status:
+      code: 201
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 17:20:17 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      status:
+      - 201 Created
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"3928a3336f01663683f92bdda358c877"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 8f90c8e4-8902-4c82-9ac2-b9e466d35b85
+      x-runtime:
+      - '0.492792'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"3011ead0-3633-0138-f020-62b37fb4c770","name":"A another
+        Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_424b9628-5405-11ea-ab18-e3a0f4f45097","uuid":"pl_3011ead0-3633-0138-f020-62b37fb4c770"}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 17:20:17 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plan_groups
+    body:
+      encoding: UTF-8
+      string: '{"name":"My plan group","plans":["pl_2f7f4360-3633-0138-f01f-62b37fb4c770","pl_3011ead0-3633-0138-f020-62b37fb4c770"]}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic OGIzNjcyOWUzMmU1OWJiMTBlNjEwZWZiOWFhNjExZTA6Nzg0MWEyNWU4Y2VkMmZjOGRmYzFhZGU3YWM0ZmFjZTQ=
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 17:20:17 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"b36573ce415d939f61a58648b6d930cf"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - a48672ef-8c37-459e-ac45-189f0e79c575
+      x-runtime:
+      - '0.079833'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"My plan group","uuid":"plg_f7e7ee61-4cff-47a5-ab45-3127cbfdde0b","plans_count":2}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 17:20:17 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/plan_groups/plg_f7e7ee61-4cff-47a5-ab45-3127cbfdde0b/plans
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic OGIzNjcyOWUzMmU1OWJiMTBlNjEwZWZiOWFhNjExZTA6Nzg0MWEyNWU4Y2VkMmZjOGRmYzFhZGU3YWM0ZmFjZTQ=
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 20 Feb 2020 17:20:18 GMT
+      content-type:
+      - application/json; charset=utf-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      x-frame-options:
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+      x-content-type-options:
+      - nosniff
+      etag:
+      - W/"5e8f9b0b2fde5db47f62e9150c0bcdad"
+      cache-control:
+      - max-age=0, private, must-revalidate
+      x-request-id:
+      - 58983eb3-fc9a-4d32-8a9f-10e6a0d82a9f
+      x-runtime:
+      - '0.366925'
+      strict-transport-security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"plans":[{"name":"A Test Plan","uuid":"pl_2f7f4360-3633-0138-f01f-62b37fb4c770","data_source_uuid":"ds_424b9628-5405-11ea-ab18-e3a0f4f45097","interval_count":1,"interval_unit":"month","external_id":"2f7f4360-3633-0138-f01f-62b37fb4c770"},{"name":"A
+        another Test Plan","uuid":"pl_3011ead0-3633-0138-f020-62b37fb4c770","data_source_uuid":"ds_424b9628-5405-11ea-ab18-e3a0f4f45097","interval_count":1,"interval_unit":"month","external_id":"3011ead0-3633-0138-f020-62b37fb4c770"}],"current_page":1,"total_pages":1}'
+    http_version: 
+  recorded_at: Thu, 20 Feb 2020 17:20:18 GMT
+recorded_with: VCR 3.0.3

--- a/lib/chartmogul.rb
+++ b/lib/chartmogul.rb
@@ -49,6 +49,8 @@ require 'chartmogul/customer'
 require 'chartmogul/data_source'
 require 'chartmogul/ping'
 require 'chartmogul/plan'
+require 'chartmogul/plan_group'
+require 'chartmogul/plan_groups/plans'
 
 require 'chartmogul/metrics/arpa'
 require 'chartmogul/metrics/arr'

--- a/lib/chartmogul/plan_group.rb
+++ b/lib/chartmogul/plan_group.rb
@@ -1,0 +1,37 @@
+module ChartMogul
+  class PlanGroup < APIResource
+    set_resource_name 'PlanGroup'
+    set_resource_path '/v1/plan_groups'
+
+    readonly_attr :uuid
+    readonly_attr :plans_count
+
+    writeable_attr :name
+    writeable_attr :plans, default: []
+
+    include API::Actions::Create
+    include API::Actions::Destroy
+    include API::Actions::Retrieve
+    include API::Actions::Update
+
+    def self.all(options = {})
+      PlanGroups.all(options)
+    end
+
+    def serialize_plans
+      plans.map(&:uuid)
+    end
+
+    class PlanGroups < APIResource
+      set_resource_name 'PlanGroups'
+      set_resource_path '/v1/plan_groups'
+
+      set_resource_root_key :plan_groups
+
+      include Concerns::Entries
+      include Concerns::Pageable2
+
+      set_entry_class PlanGroup
+    end
+  end
+end

--- a/lib/chartmogul/plan_groups/plans.rb
+++ b/lib/chartmogul/plan_groups/plans.rb
@@ -1,0 +1,15 @@
+module ChartMogul
+  module PlanGroups
+    class Plans < APIResource
+      set_resource_name 'Plans'
+      set_resource_path '/v1/plan_groups/:plan_group_uuid/plans'
+
+      set_resource_root_key :plans
+
+      include Concerns::Entries
+      include Concerns::Pageable2
+
+      set_entry_class Plan
+    end
+  end
+end

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,3 +1,3 @@
 module ChartMogul
-  VERSION = '1.4.1'.freeze
+  VERSION = '1.5.0'.freeze
 end

--- a/spec/chartmogul/plan_group_spec.rb
+++ b/spec/chartmogul/plan_group_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper'
+
+describe ChartMogul::PlanGroup do
+  describe 'API interactions', vcr: true, record: :all do
+
+    let(:data_source) do
+      ChartMogul::DataSource.create!(name: 'Data Source #1')
+    end
+
+    let(:plan1) do
+      ChartMogul::Plan.create!(
+        interval_count: 1,
+        interval_unit: 'month',
+        name: 'A Test Plan',
+        data_source_uuid: data_source.uuid
+      )
+    end
+
+    let(:plan2) do
+      ChartMogul::Plan.create!(
+        interval_count: 1,
+        interval_unit: 'month',
+        name: 'A another Test Plan',
+        data_source_uuid: data_source.uuid
+      )
+    end
+
+    let(:plan_group) do
+      ChartMogul::PlanGroup.create!(
+        name: 'My plan group',
+        plans: [plan1, plan2]
+      )
+    end
+
+    it 'returns an array of plan groups' do
+      plan_group
+
+      plan3 = ChartMogul::Plan.create!(
+        interval_count: 1,
+        interval_unit: 'month',
+        name: 'A another Test Plan',
+        data_source_uuid: data_source.uuid
+      )
+
+      second_plan_group = ChartMogul::PlanGroup.create!(
+        name: 'My second plan group',
+        plans: [plan2, plan3]
+      )
+
+      plan_groups = ChartMogul::PlanGroup.all
+
+      expect(plan_groups.map(&:uuid).sort).to eq([plan_group.uuid, second_plan_group.uuid].sort)
+      expect(plan_groups.map(&:plans_count)).to eq([2, 2])
+    end
+
+    it 'correctly handles a 422 error', uses_api: true do
+      expect { ChartMogul::PlanGroup.create! }.to raise_error(ChartMogul::ResourceInvalidError)
+    end
+
+    it 'retrieves existing plan group by uuid', uses_api: true do
+      api_pg = ChartMogul::PlanGroup.retrieve(plan_group.uuid)
+
+      expect(api_pg.uuid).to eq(plan_group.uuid)
+    end
+
+    it 'updates existing plan group name', uses_api: true do
+      new_name = 'A new plan group_name'
+      plan_group.name = new_name
+
+      plan_group.update!
+
+      api_pg = ChartMogul::PlanGroup.retrieve(plan_group.uuid)
+
+      expect(api_pg.name).to eq(new_name)
+      expect(api_pg.plans_count).to eq(2)
+    end
+
+    it 'updates existing plan group plans', uses_api: true do
+      plan3 = ChartMogul::Plan.create!(
+        interval_count: 1,
+        interval_unit: 'month',
+        name: 'A another Test Plan',
+        data_source_uuid: data_source.uuid
+      )
+      new_plans = [plan1, plan2, plan3]
+      plan_group.plans = new_plans
+
+      plan_group.update!
+
+      api_pg = ChartMogul::PlanGroup.retrieve(plan_group.uuid)
+      plans = ChartMogul::PlanGroups::Plans.all(plan_group_uuid: plan_group.uuid)
+
+      expect(api_pg.plans_count).to eq(3)
+      expect(plans.map(&:uuid).sort).to eq(new_plans.map(&:uuid).sort)
+    end
+
+    it 'deletes a plan group' do
+      plan_group.destroy!
+
+      expect do
+        ChartMogul::PlanGroup.retrieve(plan_group.uuid)
+      end.to raise_error(ChartMogul::NotFoundError)
+    end
+  end
+end

--- a/spec/chartmogul/plan_groups/plans_spec.rb
+++ b/spec/chartmogul/plan_groups/plans_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe ChartMogul::PlanGroups::Plans do
+  describe 'API interactions', vcr: true, record: :all do
+        let(:data_source) do
+          ChartMogul::DataSource.create!(name: 'Data Source #1')
+        end
+
+        let(:plan1) do
+          ChartMogul::Plan.create!(
+            interval_count: 1,
+            interval_unit: 'month',
+            name: 'A Test Plan',
+            data_source_uuid: data_source.uuid
+          )
+        end
+
+        let(:plan2) do
+          ChartMogul::Plan.create!(
+            interval_count: 1,
+            interval_unit: 'month',
+            name: 'A another Test Plan',
+            data_source_uuid: data_source.uuid
+          )
+        end
+
+        let(:plan_group) do
+          ChartMogul::PlanGroup.create!(
+            name: 'My plan group',
+            plans: [plan1, plan2]
+          )
+        end
+
+    it 'given a plan group uuid, returns an array of plans in the plan group' do
+      plans = ChartMogul::PlanGroups::Plans.all(plan_group_uuid: plan_group.uuid)
+
+      expect(plans.map(&:uuid).sort).to eq([plan1.uuid, plan2.uuid].sort)
+    end
+  end
+end

--- a/spec/chartmogul/plan_groups/plans_spec.rb
+++ b/spec/chartmogul/plan_groups/plans_spec.rb
@@ -31,7 +31,7 @@ describe ChartMogul::PlanGroups::Plans do
           )
         end
 
-    it 'given a plan group uuid, returns an array of plans in the plan group' do
+    it 'given a plan group uuid, returns an array of plans in the plan group', uses_api: true do
       plans = ChartMogul::PlanGroups::Plans.all(plan_group_uuid: plan_group.uuid)
 
       expect(plans.map(&:uuid).sort).to eq([plan1.uuid, plan2.uuid].sort)


### PR DESCRIPTION
This PR introduces two new classes:
1. `ChartMogul::PlanGroup`
2. `ChartMogul::PlanGroups::Plans`. 

It allows you to carry out the following operations on plans groups:
1. create
2. retrieve
3. update
4. destroy 
5. list

Additionally, you can list all plans in a given plan group.



