### PR TITLE
Upgrade to faraday < 1.0.0 [ch20034]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: ruby
 rvm:
   - 2.3
   - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
 
 before_install: gem install bundler
 

--- a/chartmogul-ruby.gemspec
+++ b/chartmogul-ruby.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'vcr', '~> 5.1'
   spec.add_development_dependency 'webmock', '~> 3.8'
-  spec.add_development_dependency 'simplecov', '~> 0.18.0'
+  spec.add_development_dependency 'simplecov', '~> 0.17.1'
   spec.add_development_dependency 'pry', '~> 0.12.2'
 end

--- a/chartmogul-ruby.gemspec
+++ b/chartmogul-ruby.gemspec
@@ -20,13 +20,13 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '~> 0.15.0'
+  spec.add_dependency 'faraday', '~> 0.17.3'
 
   spec.add_development_dependency 'bundler', '~> 2'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'vcr', '~> 3.0'
-  spec.add_development_dependency 'webmock', '~> 3.4', '>= 3.4.2'
-  spec.add_development_dependency 'simplecov', '~> 0.16.0'
+  spec.add_development_dependency 'vcr', '~> 5.1'
+  spec.add_development_dependency 'webmock', '~> 3.8'
+  spec.add_development_dependency 'simplecov', '~> 0.18.0'
   spec.add_development_dependency 'pry', '~> 0.12.2'
 end

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,3 +1,3 @@
 module ChartMogul
-  VERSION = '1.5.0'.freeze
+  VERSION = '1.5.1'.freeze
 end


### PR DESCRIPTION
`faraday` has released version 1.0.0, however we're not compatible yet, so I'd first do one release with latest pre-1.0.0 version.
The other dependencies are test-only.
Upgrade requested by @pcraston here: #67