### PR TITLE
Make connection thread safe

### DIFF
--- a/fixtures/vcr_cassettes/ChartMogul_APIResource/connection/works_in_a_threaded_environment.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_APIResource/connection/works_in_a_threaded_environment.yml
@@ -56,7 +56,7 @@ http_interactions:
       server:
       - nginx/1.10.1
       date:
-      - Thu, 16 Jul 2020 14:18:27 GMT
+      - Thu, 16 Jul 2020 14:18:26 GMT
       content-type:
       - application/json
       transfer-encoding:
@@ -73,5 +73,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"data":"pong!"}'
     http_version:
-  recorded_at: Thu, 16 Jul 2020 14:18:27 GMT
+  recorded_at: Thu, 16 Jul 2020 14:18:26 GMT
 recorded_with: VCR 5.1.0

--- a/fixtures/vcr_cassettes/ChartMogul_APIResource/connection/works_in_a_threaded_environment.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_APIResource/connection/works_in_a_threaded_environment.yml
@@ -21,7 +21,7 @@ http_interactions:
       server:
       - nginx/1.10.1
       date:
-      - Thu, 16 Jul 2020 14:18:26 GMT
+      - Fri, 17 Jul 2020 08:25:06 GMT
       content-type:
       - application/json
       transfer-encoding:
@@ -34,7 +34,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"code":401,"message":"No valid API key provided","param":null}'
     http_version:
-  recorded_at: Thu, 16 Jul 2020 14:18:26 GMT
+  recorded_at: Fri, 17 Jul 2020 08:25:06 GMT
 - request:
     method: get
     uri: https://api.chartmogul.com/v1/ping
@@ -56,7 +56,7 @@ http_interactions:
       server:
       - nginx/1.10.1
       date:
-      - Thu, 16 Jul 2020 14:18:26 GMT
+      - Fri, 17 Jul 2020 08:25:11 GMT
       content-type:
       - application/json
       transfer-encoding:
@@ -73,5 +73,40 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"data":"pong!"}'
     http_version:
-  recorded_at: Thu, 16 Jul 2020 14:18:26 GMT
+  recorded_at: Fri, 17 Jul 2020 08:25:11 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/ping
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic aW52YWxpZDppbnZhbGlk
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Fri, 17 Jul 2020 08:25:11 GMT
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      status:
+      - 401 Unauthorized
+    body:
+      encoding: UTF-8
+      string: '{"code":401,"message":"No valid API key provided","param":null}'
+    http_version:
+  recorded_at: Fri, 17 Jul 2020 08:25:11 GMT
 recorded_with: VCR 5.1.0

--- a/fixtures/vcr_cassettes/ChartMogul_APIResource/connection/works_when_credentials_are_updated.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_APIResource/connection/works_when_credentials_are_updated.yml
@@ -1,0 +1,151 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/ping
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 16 Jul 2020 13:12:25 GMT
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":"pong!"}'
+    http_version:
+  recorded_at: Thu, 16 Jul 2020 13:12:25 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/ping
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic aW52YWxpZDppbnZhbGlk
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 16 Jul 2020 13:12:25 GMT
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      status:
+      - 401 Unauthorized
+    body:
+      encoding: UTF-8
+      string: '{"code":401,"message":"No valid API key provided","param":null}'
+    http_version:
+  recorded_at: Thu, 16 Jul 2020 13:12:25 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/ping
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic aW52YWxpZDppbnZhbGlk
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 16 Jul 2020 13:12:25 GMT
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      status:
+      - 401 Unauthorized
+    body:
+      encoding: UTF-8
+      string: '{"code":401,"message":"No valid API key provided","param":null}'
+    http_version:
+  recorded_at: Thu, 16 Jul 2020 13:12:25 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/ping
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Thu, 16 Jul 2020 13:12:26 GMT
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"data":"pong!"}'
+    http_version:
+  recorded_at: Thu, 16 Jul 2020 13:12:26 GMT
+recorded_with: VCR 5.1.0

--- a/fixtures/vcr_cassettes/ChartMogul_APIResource/connection/works_when_credentials_are_updated.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_APIResource/connection/works_when_credentials_are_updated.yml
@@ -21,7 +21,7 @@ http_interactions:
       server:
       - nginx/1.10.1
       date:
-      - Thu, 16 Jul 2020 14:18:26 GMT
+      - Fri, 17 Jul 2020 08:25:25 GMT
       content-type:
       - application/json
       transfer-encoding:
@@ -34,7 +34,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"code":401,"message":"No valid API key provided","param":null}'
     http_version:
-  recorded_at: Thu, 16 Jul 2020 14:18:26 GMT
+  recorded_at: Fri, 17 Jul 2020 08:25:25 GMT
 - request:
     method: get
     uri: https://api.chartmogul.com/v1/ping
@@ -56,7 +56,7 @@ http_interactions:
       server:
       - nginx/1.10.1
       date:
-      - Thu, 16 Jul 2020 14:18:27 GMT
+      - Fri, 17 Jul 2020 08:25:26 GMT
       content-type:
       - application/json
       transfer-encoding:
@@ -73,5 +73,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"data":"pong!"}'
     http_version:
-  recorded_at: Thu, 16 Jul 2020 14:18:27 GMT
+  recorded_at: Fri, 17 Jul 2020 08:25:26 GMT
 recorded_with: VCR 5.1.0

--- a/lib/chartmogul/api_resource.rb
+++ b/lib/chartmogul/api_resource.rb
@@ -15,7 +15,7 @@ module ChartMogul
     INTERVAL_RANDOMNESS = 0.5
     INTERVAL = 1
     MAX_INTERVAL = 60
-    THREAD_PREFIX = 'chartmogul_ruby.connection'
+    THREAD_CONNECTION_KEY = 'chartmogul_ruby.api_resource.connection'
 
     class << self; attr_reader :resource_path, :resource_name, :resource_root_key end
 
@@ -32,8 +32,7 @@ module ChartMogul
     end
 
     def self.connection
-      Thread.current["#{THREAD_PREFIX}.connection"] = build_connection if creds_changed?
-      Thread.current["#{THREAD_PREFIX}.connection"]
+      Thread.current[THREAD_CONNECTION_KEY] ||= build_connection
     end
 
     def self.handling_errors
@@ -80,26 +79,15 @@ module ChartMogul
 
     private
 
-    def self.creds_changed?
-      Thread.current['chartmogul_ruby.connection.account_token'] != ChartMogul.account_token ||
-        Thread.current['chartmogul_ruby.connection.secret_key'] != ChartMogul.secret_key
-    end
-
     def self.build_connection
-      cache_credentials
       Faraday.new(url: ChartMogul::API_BASE) do |faraday|
-        faraday.use Faraday::Request::BasicAuthentication, Thread.current["#{THREAD_PREFIX}.account_token"], Thread.current["#{THREAD_PREFIX}.secret_key"]
+        faraday.use Faraday::Request::BasicAuthentication, ChartMogul.account_token, ChartMogul.secret_key
         faraday.use Faraday::Response::RaiseError
         faraday.request :retry, max: ChartMogul.max_retries, retry_statuses: RETRY_STATUSES,
                                 max_interval: MAX_INTERVAL, backoff_factor: BACKOFF_FACTOR,
                                 interval_randomness: INTERVAL_RANDOMNESS, interval: INTERVAL, exceptions: RETRY_EXCEPTIONS
         faraday.use Faraday::Adapter::NetHttp
       end
-    end
-
-    def self.cache_credentials
-      Thread.current["#{THREAD_PREFIX}.account_token"] = ChartMogul.account_token
-      Thread.current["#{THREAD_PREFIX}.secret_key"] = ChartMogul.secret_key
     end
   end
 end

--- a/lib/chartmogul/api_resource.rb
+++ b/lib/chartmogul/api_resource.rb
@@ -15,6 +15,7 @@ module ChartMogul
     INTERVAL_RANDOMNESS = 0.5
     INTERVAL = 1
     MAX_INTERVAL = 60
+    THREAD_PREFIX = 'chartmogul_ruby.connection'
 
     class << self; attr_reader :resource_path, :resource_name, :resource_root_key end
 
@@ -31,14 +32,8 @@ module ChartMogul
     end
 
     def self.connection
-      @connection ||= Faraday.new(url: ChartMogul::API_BASE) do |faraday|
-        faraday.use Faraday::Request::BasicAuthentication, ChartMogul.account_token, ChartMogul.secret_key
-        faraday.use Faraday::Response::RaiseError
-        faraday.request :retry, max: ChartMogul.max_retries, retry_statuses: RETRY_STATUSES,
-                                max_interval: MAX_INTERVAL, backoff_factor: BACKOFF_FACTOR,
-                                interval_randomness: INTERVAL_RANDOMNESS, interval: INTERVAL, exceptions: RETRY_EXCEPTIONS
-        faraday.use Faraday::Adapter::NetHttp
-      end
+      Thread.current["#{THREAD_PREFIX}.connection"] = build_connection if creds_changed?
+      Thread.current["#{THREAD_PREFIX}.connection"]
     end
 
     def self.handling_errors
@@ -82,5 +77,29 @@ module ChartMogul
     end
 
     def_delegators 'self.class', :resource_path, :resource_name, :resource_root_key, :connection, :handling_errors
+
+    private
+
+    def self.creds_changed?
+      Thread.current['chartmogul_ruby.connection.account_token'] != ChartMogul.account_token ||
+        Thread.current['chartmogul_ruby.connection.secret_key'] != ChartMogul.secret_key
+    end
+
+    def self.build_connection
+      cache_credentials
+      Faraday.new(url: ChartMogul::API_BASE) do |faraday|
+        faraday.use Faraday::Request::BasicAuthentication, Thread.current["#{THREAD_PREFIX}.account_token"], Thread.current["#{THREAD_PREFIX}.secret_key"]
+        faraday.use Faraday::Response::RaiseError
+        faraday.request :retry, max: ChartMogul.max_retries, retry_statuses: RETRY_STATUSES,
+                                max_interval: MAX_INTERVAL, backoff_factor: BACKOFF_FACTOR,
+                                interval_randomness: INTERVAL_RANDOMNESS, interval: INTERVAL, exceptions: RETRY_EXCEPTIONS
+        faraday.use Faraday::Adapter::NetHttp
+      end
+    end
+
+    def self.cache_credentials
+      Thread.current["#{THREAD_PREFIX}.account_token"] = ChartMogul.account_token
+      Thread.current["#{THREAD_PREFIX}.secret_key"] = ChartMogul.secret_key
+    end
   end
 end

--- a/lib/chartmogul/config_attributes.rb
+++ b/lib/chartmogul/config_attributes.rb
@@ -14,6 +14,7 @@ module ChartMogul
 
       define_method("#{attribute}=") do |val|
         config.send("#{attribute}=", val)
+        Thread.current[ChartMogul::APIResource::THREAD_CONNECTION_KEY] = nil
       end
     end
   end

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ChartMogul
-  VERSION = '1.6.0'
+  VERSION = '1.6.1'
 end

--- a/spec/chartmogul/api_resource_spec.rb
+++ b/spec/chartmogul/api_resource_spec.rb
@@ -3,13 +3,33 @@
 require 'spec_helper'
 
 describe ChartMogul::APIResource do
-  describe 'connection', vcr: true do
-    it 'works when credentials are updated', vcr: { record: :all } do
+  before do
+    WebMock.allow_net_connect!
+  end
+  after do
+    WebMock.disable_net_connect!
+  end
+
+  describe 'connection' do
+    it 'works when credentials are updated', vcr: { record: :all, exclusive: true } do
       set_invalid_credentials
       expect { ChartMogul::Ping.ping }.to raise_error(ChartMogul::UnauthorizedError)
 
       set_valid_credentials
-      expect { ChartMogul::Ping.ping }.not_to raise_error(ChartMogul::UnauthorizedError)
+      expect { ChartMogul::Ping.ping }.not_to raise_error
+    end
+
+    it 'works in a threaded environment', vcr: { record: :all, exclusive: true } do
+      t1 = Thread.new do
+        set_invalid_credentials
+        expect { ChartMogul::Ping.ping }.to raise_error(ChartMogul::UnauthorizedError)
+      end
+
+      t2 = Thread.new do
+        set_valid_credentials
+        expect { ChartMogul::Ping.ping }.not_to raise_error
+      end
+      [t1, t2].join
     end
   end
 

--- a/spec/chartmogul/api_resource_spec.rb
+++ b/spec/chartmogul/api_resource_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ChartMogul::APIResource do
+  describe 'connection', vcr: true do
+    it 'works when credentials are updated', vcr: { record: :all } do
+      set_invalid_credentials
+      expect { ChartMogul::Ping.ping }.to raise_error(ChartMogul::UnauthorizedError)
+
+      set_valid_credentials
+      expect { ChartMogul::Ping.ping }.not_to raise_error(ChartMogul::UnauthorizedError)
+    end
+  end
+
+  def set_valid_credentials
+    ChartMogul.account_token = 'dummy-token'
+    ChartMogul.secret_key = 'dummy-token'
+  end
+
+  def set_invalid_credentials
+    ChartMogul.account_token = 'invalid'
+    ChartMogul.secret_key = 'invalid'
+  end
+end

--- a/spec/chartmogul/api_resource_spec.rb
+++ b/spec/chartmogul/api_resource_spec.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'pry'
 
 describe ChartMogul::APIResource do
-  describe 'connection' do
-    it 'works when credentials are updated', vcr: { record: :all, exclusive: true } do
+  describe 'connection', vcr: true do
+    it 'works when credentials are updated' do
       set_invalid_credentials
       expect { ChartMogul::Ping.ping }.to raise_error(ChartMogul::UnauthorizedError)
 
@@ -12,17 +13,14 @@ describe ChartMogul::APIResource do
       expect { ChartMogul::Ping.ping }.not_to raise_error
     end
 
-    it 'works in a threaded environment', vcr: { record: :all, exclusive: true } do
-      t1 = Thread.new do
-        set_invalid_credentials
-        expect { ChartMogul::Ping.ping }.to raise_error(ChartMogul::UnauthorizedError)
-      end
+    it 'works in a threaded environment' do
+      set_invalid_credentials
+      expect { ChartMogul::Ping.ping }.to raise_error(ChartMogul::UnauthorizedError)
 
-      t2 = Thread.new do
+      Thread.new do
         set_valid_credentials
         expect { ChartMogul::Ping.ping }.not_to raise_error
-      end
-      [t1, t2].join
+      end.join
     end
   end
 

--- a/spec/chartmogul/api_resource_spec.rb
+++ b/spec/chartmogul/api_resource_spec.rb
@@ -3,13 +3,6 @@
 require 'spec_helper'
 
 describe ChartMogul::APIResource do
-  before do
-    WebMock.allow_net_connect!
-  end
-  after do
-    WebMock.disable_net_connect!
-  end
-
   describe 'connection' do
     it 'works when credentials are updated', vcr: { record: :all, exclusive: true } do
       set_invalid_credentials

--- a/spec/chartmogul/api_resource_spec.rb
+++ b/spec/chartmogul/api_resource_spec.rb
@@ -21,6 +21,8 @@ describe ChartMogul::APIResource do
         set_valid_credentials
         expect { ChartMogul::Ping.ping }.not_to raise_error
       end.join
+
+      expect { ChartMogul::Ping.ping }.to raise_error(ChartMogul::UnauthorizedError)
     end
   end
 

--- a/spec/chartmogul/retry_spec.rb
+++ b/spec/chartmogul/retry_spec.rb
@@ -6,7 +6,7 @@ describe 'chartmogul retry request' do
   let(:url) { 'https://api.chartmogul.com/v1/customers/search?email=no@email.com' }
 
   before do
-    ChartMogul::Customers.instance_variable_set(:@connection, nil) # clearing memoized connection
+    Thread.current[ChartMogul::APIResource::THREAD_CONNECTION_KEY] = nil
     config = instance_double(
       'ChartMogul::Configuration', account_token: 'dummy-token',
                                    secret_key: 'dummy-token', max_retries: max_retries


### PR DESCRIPTION
`@connection` class variable in `ChartMogul::APIResource` caching connection credentials which lead to an unexpected result if credentials are changed in runtime. This PR makes `@connection` threadsafe and clears it if credentials are changed.