### PR TITLE
Add support for direct update requests [ch23601]

### DIFF
--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/updates_customer_using_class_method.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/updates_customer_using_class_method.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://api.chartmogul.com/v1/customers/cus_a29bbcb6-43ed-11e9-9bff-a3a747d175b1
+    body:
+      encoding: UTF-8
+      string: '{"attributes":{"custom":{"company_size":"just me"},"tags":["foobar"]},"email":"curry@example.com","company":"Curry
+        42","country":"IN","state":"NY","city":"Berlin","free_trial_started_at":"2020-02-02
+        22:40:00 UTC"}'
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.1
+      Date:
+      - Fri, 17 Jul 2020 12:10:11 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Status:
+      - 200 OK
+      Access-Control-Allow-Credentials:
+      - 'true'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":33802170,"uuid":"cus_a29bbcb6-43ed-11e9-9bff-a3a747d175b1","external_id":"HngTohkREePdXBIx","name":"Currywurst","email":"curry@example.com","status":"Past
+        due","customer-since":"2018-12-29T00:00:00+00:00","attributes":{"custom":{"company_size":"just
+        me","Users":"1"},"clearbit":{},"stripe":{},"tags":["foobar"]},"data_source_uuid":"ds_b835f746-43eb-11e9-8169-9333ac374c59","data_source_uuids":["ds_b835f746-43eb-11e9-8169-9333ac374c59"],"external_ids":["HngTohkREePdXBIx"],"company":"Curry
+        42","country":"IN","state":"NY","city":"Berlin","zip":null,"lead_created_at":"2018-12-15T00:00:00.000Z","free_trial_started_at":"2020-02-02T22:40:00.000Z","address":{"country":"India","state":"New
+        York","city":"Berlin","address_zip":null},"mrr":4900,"arr":58800,"billing-system-url":"HngTohkREePdXBIx","chartmogul-url":"https://app.chartmogul.com/#customers/33802170-Currywurst","billing-system-type":"Chargebee","currency":"USD","currency-sign":"$"}'
+    http_version: null
+  recorded_at: Fri, 17 Jul 2020 12:10:11 GMT
+recorded_with: VCR 5.1.0

--- a/lib/chartmogul/api/actions/update.rb
+++ b/lib/chartmogul/api/actions/update.rb
@@ -4,6 +4,10 @@ module ChartMogul
   module API
     module Actions
       module Update
+        def self.included(base)
+          base.extend ClassMethods
+        end
+
         def update!
           resp = handling_errors do
             connection.patch("#{resource_path.apply(instance_attributes)}/#{uuid}") do |req|
@@ -14,6 +18,22 @@ module ChartMogul
           json = ChartMogul::Utils::JSONParser.parse(resp.body)
 
           assign_all_attributes(json)
+        end
+
+        module ClassMethods
+          def update!(uuid, attributes = {})
+            resource = new(attributes)
+
+            resp = handling_errors do
+              connection.patch("#{resource_path.apply(attributes)}/#{uuid}") do |req|
+                req.headers['Content-Type'] = 'application/json'
+                req.body = JSON.dump(resource.serialize_for_write)
+              end
+            end
+            json = ChartMogul::Utils::JSONParser.parse(resp.body)
+
+            new_from_json(json)
+          end
         end
       end
     end

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ChartMogul
-  VERSION = '1.6.1'
+  VERSION = '1.6.2'
 end

--- a/spec/chartmogul/customer_spec.rb
+++ b/spec/chartmogul/customer_spec.rb
@@ -287,6 +287,32 @@ describe ChartMogul::Customer do
       expect(updated_customer.attributes[:custom][:meinung]).to eq ['lecker']
     end
 
+    it 'updates customer using class method', uses_api: true do
+      customer_uuid = 'cus_a29bbcb6-43ed-11e9-9bff-a3a747d175b1'
+
+      updated_customer = described_class.update!(customer_uuid, {
+        email: 'curry@example.com',
+        company: 'Curry 42',
+        country: 'IN',
+        state: 'NY',
+        city: 'Berlin',
+        free_trial_started_at: Time.utc(2020, 2, 2, 22, 40),
+        attributes: {
+          custom: {
+            company_size: 'just me'
+          },
+          tags: ['foobar']
+        }
+      })
+
+      expect(updated_customer.uuid).to eq customer_uuid
+      expect(updated_customer.name).to eq 'Currywurst'
+      expect(updated_customer.email).to eq 'curry@example.com'
+      expect(updated_customer.address).to eq(country: 'India', state: 'New York', city: 'Berlin', address_zip: nil)
+      expect(updated_customer.attributes[:tags]).to eq ['foobar']
+      expect(updated_customer.attributes[:custom][:company_size]).to eq 'just me'
+    end
+
     it 'raises 422 for update with invalid data', uses_api: true do
       customer_uuid = 'cus_782b0716-a728-11e6-8eab-a7d0e8cd5c1e'
       customer = described_class.retrieve(customer_uuid)


### PR DESCRIPTION
**Reason For Change**
Ruby client does not support making direct update requests to the Import API. It allows you to perform update requests only after you fetch the entity from Import API as shown in `Current Behaviour` below. This leads to making 2 requests even if you have `customer_uuid` cached/persisted in the integration code.

**Impacted types of users**
Import API consumers using the `chartmogul-ruby` client library, at the moment need to either make a request for the entity before updating or construct the entity explicitly and then issue `update!`
 
**Current behaviour**
From API reference 
```ruby
customer = ChartMogul::Customer.retrieve("cus_dummy_uuid")  # makes 1 request
customer.city = "San Francisco"
customer.country = "US"
<... reducing changes for brevity ...>
customer.update! # makes an additional request
```
**New behaviour**
```ruby
ChartMogul::Customer.update!(
    "cus_dummy_uuid",
    lead_created_at: "2015-01-01 00:00:00",
    free_trial_started_at: "2015-06-13 15:45:13",
    city: "San Francisco",
    country: "US"
); # makes just 1 request for the update accepts the parameters listed in https://dev.chartmogul.com/reference#update-a-customer

```