### PR TITLE
Add support for direct update requests [ch23601]

### DIFF
--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/updates_customer_using_class_method.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/updates_customer_using_class_method.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://api.chartmogul.com/v1/customers/cus_a29bbcb6-43ed-11e9-9bff-a3a747d175b1
+    body:
+      encoding: UTF-8
+      string: '{"attributes":{"custom":{"company_size":"just me"},"tags":["foobar"]},"email":"curry@example.com","company":"Curry
+        42","country":"IN","state":"NY","city":"Berlin","free_trial_started_at":"2020-02-02
+        22:40:00 UTC"}'
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.1
+      Date:
+      - Fri, 17 Jul 2020 12:10:11 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Status:
+      - 200 OK
+      Access-Control-Allow-Credentials:
+      - 'true'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":33802170,"uuid":"cus_a29bbcb6-43ed-11e9-9bff-a3a747d175b1","external_id":"HngTohkREePdXBIx","name":"Currywurst","email":"curry@example.com","status":"Past
+        due","customer-since":"2018-12-29T00:00:00+00:00","attributes":{"custom":{"company_size":"just
+        me","Users":"1"},"clearbit":{},"stripe":{},"tags":["foobar"]},"data_source_uuid":"ds_b835f746-43eb-11e9-8169-9333ac374c59","data_source_uuids":["ds_b835f746-43eb-11e9-8169-9333ac374c59"],"external_ids":["HngTohkREePdXBIx"],"company":"Curry
+        42","country":"IN","state":"NY","city":"Berlin","zip":null,"lead_created_at":"2018-12-15T00:00:00.000Z","free_trial_started_at":"2020-02-02T22:40:00.000Z","address":{"country":"India","state":"New
+        York","city":"Berlin","address_zip":null},"mrr":4900,"arr":58800,"billing-system-url":"HngTohkREePdXBIx","chartmogul-url":"https://app.chartmogul.com/#customers/33802170-Currywurst","billing-system-type":"Chargebee","currency":"USD","currency-sign":"$"}'
+    http_version: null
+  recorded_at: Fri, 17 Jul 2020 12:10:11 GMT
+recorded_with: VCR 5.1.0

--- a/fixtures/vcr_cassettes/ChartMogul_Plan/API_Interactions/updates_existing_plan_using_class_method.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Plan/API_Interactions/updates_existing_plan_using_class_method.yml
@@ -1,0 +1,164 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/data_sources
+    body:
+      encoding: UTF-8
+      string: '{"name":"Another Data Source"}'
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx/1.10.1
+      Date:
+      - Thu, 23 Jul 2020 12:33:56 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 201 Created
+      Access-Control-Allow-Credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"uuid":"ds_c65f219c-cce0-11ea-a43a-8745a9a809c7","name":"Another Data
+        Source","system":"Import API","created_at":"2020-07-23T12:33:56.076Z","status":"idle"}'
+    http_version: null
+  recorded_at: Thu, 23 Jul 2020 12:33:56 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plans
+    body:
+      encoding: UTF-8
+      string: '{"name":"pro","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_c65f219c-cce0-11ea-a43a-8745a9a809c7"}'
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx/1.10.1
+      Date:
+      - Thu, 23 Jul 2020 12:33:57 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 201 Created
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Etag:
+      - W/"ea419983710a24c40e13cc17133cfad5"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 8c6f92d6-c5f2-47ec-9bca-bb42bf2906bd
+      X-Runtime:
+      - '0.107610'
+      Strict-Transport-Security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"b37d52c0-af0e-0138-9570-42eead14b4ad","name":"pro","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_c65f219c-cce0-11ea-a43a-8745a9a809c7","uuid":"pl_b37d52c0-af0e-0138-9570-42eead14b4ad"}'
+    http_version: null
+  recorded_at: Thu, 23 Jul 2020 12:33:57 GMT
+- request:
+    method: patch
+    uri: https://api.chartmogul.com/v1/plans/pl_b37d52c0-af0e-0138-9570-42eead14b4ad
+    body:
+      encoding: UTF-8
+      string: '{"name":"really pro","interval_count":2}'
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.10.1
+      Date:
+      - Thu, 23 Jul 2020 12:33:58 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - fcc52966-8abd-442b-a9cd-e14a35988163
+      X-Runtime:
+      - '0.125362'
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"b37d52c0-af0e-0138-9570-42eead14b4ad","name":"really
+        pro","interval_count":2,"interval_unit":"month","data_source_uuid":"ds_c65f219c-cce0-11ea-a43a-8745a9a809c7","uuid":"pl_b37d52c0-af0e-0138-9570-42eead14b4ad"}'
+    http_version: null
+  recorded_at: Thu, 23 Jul 2020 12:33:58 GMT
+recorded_with: VCR 5.1.0

--- a/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/updates_existing_plan_group_name_via_class_method.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/updates_existing_plan_group_name_via_class_method.yml
@@ -1,0 +1,297 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/data_sources
+    body:
+      encoding: UTF-8
+      string: '{"name":"Data Source #1"}'
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx/1.10.1
+      Date:
+      - Thu, 23 Jul 2020 12:34:26 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 201 Created
+      Access-Control-Allow-Credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"uuid":"ds_d83adf5a-cce0-11ea-a43a-0bee9fce502d","name":"Data Source
+        #1","system":"Import API","created_at":"2020-07-23T12:34:26.033Z","status":"idle"}'
+    http_version: null
+  recorded_at: Thu, 23 Jul 2020 12:34:26 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plans
+    body:
+      encoding: UTF-8
+      string: '{"name":"A Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_d83adf5a-cce0-11ea-a43a-0bee9fce502d"}'
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx/1.10.1
+      Date:
+      - Thu, 23 Jul 2020 12:34:27 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 201 Created
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Etag:
+      - W/"c69ec995cb9bab078fd6c88a194a33e0"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 21bb8417-4520-4b9f-aded-46d155615e98
+      X-Runtime:
+      - '0.119008'
+      Strict-Transport-Security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"c5723000-af0e-0138-d912-62b37fb4c770","name":"A Test
+        Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_d83adf5a-cce0-11ea-a43a-0bee9fce502d","uuid":"pl_c5723000-af0e-0138-d912-62b37fb4c770"}'
+    http_version: null
+  recorded_at: Thu, 23 Jul 2020 12:34:27 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plans
+    body:
+      encoding: UTF-8
+      string: '{"name":"A another Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_d83adf5a-cce0-11ea-a43a-0bee9fce502d"}'
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Server:
+      - nginx/1.10.1
+      Date:
+      - Thu, 23 Jul 2020 12:34:28 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Status:
+      - 201 Created
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Etag:
+      - W/"392434626ecc2ec07e9bb64179d07e58"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f9570c06-bfc2-4cce-b9e2-ec2ad88e2a1a
+      X-Runtime:
+      - '0.114808'
+      Strict-Transport-Security:
+      - max-age=15768000
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"c61dc800-af0e-0138-1702-4e501129bd4a","name":"A another
+        Test Plan","interval_count":1,"interval_unit":"month","data_source_uuid":"ds_d83adf5a-cce0-11ea-a43a-0bee9fce502d","uuid":"pl_c61dc800-af0e-0138-1702-4e501129bd4a"}'
+    http_version: null
+  recorded_at: Thu, 23 Jul 2020 12:34:28 GMT
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/plan_groups
+    body:
+      encoding: UTF-8
+      string: '{"name":"My plan group","plans":["pl_c5723000-af0e-0138-d912-62b37fb4c770","pl_c61dc800-af0e-0138-1702-4e501129bd4a"]}'
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.1
+      Date:
+      - Thu, 23 Jul 2020 12:34:29 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Etag:
+      - W/"1b33f81c506f9371501c358293e5c25e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 96425a8f-ad6a-4d43-883a-28809e5e8fd2
+      X-Runtime:
+      - '0.055173'
+      Strict-Transport-Security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"My plan group","uuid":"plg_36d737ca-b021-4fc7-a8ee-8636fb6db2cc","plans_count":2}'
+    http_version: null
+  recorded_at: Thu, 23 Jul 2020 12:34:29 GMT
+- request:
+    method: patch
+    uri: https://api.chartmogul.com/v1/plan_groups/plg_36d737ca-b021-4fc7-a8ee-8636fb6db2cc
+    body:
+      encoding: UTF-8
+      string: '{"name":"A new group name"}'
+    headers:
+      User-Agent:
+      - Faraday v0.17.3
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.10.1
+      Date:
+      - Thu, 23 Jul 2020 12:34:30 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Etag:
+      - W/"b12ead83619d709fd1285016e6daec9b"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 27ca96d6-4e17-4c89-b030-6fcae8131bb3
+      X-Runtime:
+      - '0.044140'
+      Strict-Transport-Security:
+      - max-age=15768000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"name":"A new group name","uuid":"plg_36d737ca-b021-4fc7-a8ee-8636fb6db2cc","plans_count":2}'
+    http_version: null
+  recorded_at: Thu, 23 Jul 2020 12:34:30 GMT
+recorded_with: VCR 5.1.0

--- a/lib/chartmogul/api/actions/update.rb
+++ b/lib/chartmogul/api/actions/update.rb
@@ -4,6 +4,10 @@ module ChartMogul
   module API
     module Actions
       module Update
+        def self.included(base)
+          base.extend ClassMethods
+        end
+
         def update!
           resp = handling_errors do
             connection.patch("#{resource_path.apply(instance_attributes)}/#{uuid}") do |req|
@@ -14,6 +18,22 @@ module ChartMogul
           json = ChartMogul::Utils::JSONParser.parse(resp.body)
 
           assign_all_attributes(json)
+        end
+
+        module ClassMethods
+          def update!(uuid, attributes = {})
+            resource = new(attributes)
+
+            resp = handling_errors do
+              connection.patch("#{resource_path.apply(attributes)}/#{uuid}") do |req|
+                req.headers['Content-Type'] = 'application/json'
+                req.body = JSON.dump(resource.serialize_for_write)
+              end
+            end
+            json = ChartMogul::Utils::JSONParser.parse(resp.body)
+
+            new_from_json(json)
+          end
         end
       end
     end

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ChartMogul
-  VERSION = '1.6.1'
+  VERSION = '1.6.2'
 end

--- a/spec/chartmogul/customer_spec.rb
+++ b/spec/chartmogul/customer_spec.rb
@@ -287,7 +287,7 @@ describe ChartMogul::Customer do
       expect(updated_customer.attributes[:custom][:meinung]).to eq ['lecker']
     end
 
-    it 'updates customer using class method', uses_api: true do
+    it 'updates customer using class method', uses_api: true, match_requests_on: [:method, :uri, :body] do
       customer_uuid = 'cus_a29bbcb6-43ed-11e9-9bff-a3a747d175b1'
 
       updated_customer = described_class.update!(customer_uuid, {

--- a/spec/chartmogul/customer_spec.rb
+++ b/spec/chartmogul/customer_spec.rb
@@ -287,6 +287,32 @@ describe ChartMogul::Customer do
       expect(updated_customer.attributes[:custom][:meinung]).to eq ['lecker']
     end
 
+    it 'updates customer using class method', uses_api: true do
+      customer_uuid = 'cus_a29bbcb6-43ed-11e9-9bff-a3a747d175b1'
+
+      updated_customer = described_class.update!(customer_uuid, {
+        email: 'curry@example.com',
+        company: 'Curry 42',
+        country: 'IN',
+        state: 'NY',
+        city: 'Berlin',
+        free_trial_started_at: Time.utc(2020, 2, 2, 22, 40),
+        attributes: {
+          custom: {
+            company_size: 'just me'
+          },
+          tags: ['foobar']
+        }
+      })
+
+      expect(updated_customer.uuid).to eq customer_uuid
+      expect(updated_customer.name).to eq 'Currywurst'
+      expect(updated_customer.email).to eq 'curry@example.com'
+      expect(updated_customer.address).to eq(country: 'India', state: 'New York', city: 'Berlin', address_zip: nil)
+      expect(updated_customer.attributes[:tags]).to eq ['foobar']
+      expect(updated_customer.attributes[:custom][:company_size]).to eq 'just me'
+    end
+
     it 'raises 422 for update with invalid data', uses_api: true do
       customer_uuid = 'cus_782b0716-a728-11e6-8eab-a7d0e8cd5c1e'
       customer = described_class.retrieve(customer_uuid)

--- a/spec/chartmogul/plan_group_spec.rb
+++ b/spec/chartmogul/plan_group_spec.rb
@@ -76,6 +76,17 @@ describe ChartMogul::PlanGroup, uses_api: true do
       expect(api_pg.plans_count).to eq(2)
     end
 
+    it 'updates existing plan group name via class method', uses_api: true, match_requests_on: [:method, :uri, :body] do
+      new_name = 'A new group name'
+
+      updated_pg = described_class.update!(plan_group.uuid, {
+        name: new_name
+      })
+
+      expect(updated_pg.name).to eq(new_name)
+      expect(updated_pg.plans_count).to eq(2)
+    end
+
     it 'updates existing plan group plans', uses_api: true do
       plan3 = ChartMogul::Plan.create!(
         interval_count: 1,

--- a/spec/chartmogul/plan_spec.rb
+++ b/spec/chartmogul/plan_spec.rb
@@ -61,6 +61,25 @@ describe ChartMogul::Plan do
       expect(plan.interval_count).to eq(2)
     end
 
+    it 'updates existing plan using class method', uses_api: true, match_requests_on: [:method, :uri, :body] do
+      data_source = ChartMogul::DataSource.create!(name: 'Another Data Source')
+
+      plan = described_class.create!(
+        interval_count: 1,
+        interval_unit: 'month',
+        name: 'pro',
+        data_source_uuid: data_source.uuid
+      )
+
+      updated_plan = described_class.update!(plan.uuid, {
+        interval_count: 2,
+        name: 'really pro'
+      })
+
+      expect(updated_plan.interval_count).to eq(2)
+      expect(updated_plan.name).to eq('really pro')
+    end
+
     it 'deletes existing plan', uses_api: true do
       data_source = ChartMogul::DataSource.create!(name: 'Another Data Source')
 


### PR DESCRIPTION
**Reason For Change**
Ruby client does not support making direct update requests to the Import API. It allows you to perform update requests only after you fetch the entity from Import API as shown in `Current Behaviour` below. This leads to making 2 requests even if you have `customer_uuid` cached/persisted in the integration code.

**Impacted types of users**
Import API consumers using the `chartmogul-ruby` client library, at the moment need to either make a request for the entity before updating or construct the entity explicitly and then issue `update!`
 
**Current behaviour**
From API reference 
```ruby
customer = ChartMogul::Customer.retrieve("cus_dummy_uuid")  # makes 1 request
customer.city = "San Francisco"
customer.country = "US"
<... reducing changes for brevity ...>
customer.update! # makes an additional request
```
**New behaviour**
```ruby
ChartMogul::Customer.update!(
    "cus_dummy_uuid",
    lead_created_at: "2015-01-01 00:00:00",
    free_trial_started_at: "2015-06-13 15:45:13",
    city: "San Francisco",
    country: "US"
); # makes just 1 request for the update accepts the parameters listed in https://dev.chartmogul.com/reference#update-a-customer

```