### PR TITLE
Add support for changing domain [ch23946]

### DIFF
--- a/lib/chartmogul.rb
+++ b/lib/chartmogul.rb
@@ -73,11 +73,11 @@ require 'chartmogul/enrichment/customer'
 module ChartMogul
   API_BASE = 'https://api.chartmogul.com'
   MAX_RETRIES = 20
+  CONFIG_THREAD_KEY = 'chartmogul_ruby.config'
 
   class << self
     extend ConfigAttributes
 
-    CONFIG_THREAD_KEY = 'chartmogul_ruby.config'
 
     def config
       Thread.current[CONFIG_THREAD_KEY] = ChartMogul::Configuration.new if Thread.current[CONFIG_THREAD_KEY].nil?

--- a/lib/chartmogul.rb
+++ b/lib/chartmogul.rb
@@ -87,5 +87,6 @@ module ChartMogul
     config_accessor :account_token
     config_accessor :secret_key
     config_accessor :max_retries, MAX_RETRIES
+    config_accessor :api_base, API_BASE
   end
 end

--- a/lib/chartmogul/api_resource.rb
+++ b/lib/chartmogul/api_resource.rb
@@ -80,7 +80,7 @@ module ChartMogul
     private
 
     def self.build_connection
-      Faraday.new(url: ChartMogul::API_BASE) do |faraday|
+      Faraday.new(url: ChartMogul.api_base) do |faraday|
         faraday.use Faraday::Request::BasicAuthentication, ChartMogul.account_token, ChartMogul.secret_key
         faraday.use Faraday::Response::RaiseError
         faraday.request :retry, max: ChartMogul.max_retries, retry_statuses: RETRY_STATUSES,

--- a/lib/chartmogul/configuration.rb
+++ b/lib/chartmogul/configuration.rb
@@ -5,5 +5,6 @@ module ChartMogul
     attr_accessor :account_token
     attr_accessor :secret_key
     attr_accessor :max_retries
+    attr_accessor :api_base
   end
 end

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ChartMogul
-  VERSION = '1.6.2'
+  VERSION = '1.6.3'
 end

--- a/spec/chartmogul/configuration_spec.rb
+++ b/spec/chartmogul/configuration_spec.rb
@@ -26,4 +26,19 @@ describe 'ChartMogul configuration' do
       expect { ChartMogul.secret_key }.to raise_error(ChartMogul::ConfigurationError)
     end
   end
+
+  describe 'api base' do
+    it 'sets the api base' do
+      dummy_base = 'https://dummy-api.chartmogul.com'
+
+      ChartMogul.api_base = dummy_base
+      expect(ChartMogul.api_base).to eq dummy_base
+    end
+
+    it 'uses default api base when not set' do
+      ChartMogul.api_base = nil
+
+      expect(ChartMogul.api_base).to eq ChartMogul::API_BASE
+    end
+  end
 end

--- a/spec/chartmogul/connection_cache_spec.rb
+++ b/spec/chartmogul/connection_cache_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Connection cache' do
+  before do
+    stub_request(:get, "https://api.chartmogul.com/v1/ping").
+    to_return(status: 200, body: '{"data":"pong!"}')
+
+    stub_request(:get, "https://example.chartmogul.com/v1/ping").
+    to_return(status: 200, body: '{"data":"pong!"}')
+  end
+
+
+  it 'invalidates the connection and uses new one' do
+    VCR.turned_off do
+      ChartMogul.account_token = 'dummy-token'
+      ChartMogul.secret_key = 'dummy-token'
+      ChartMogul.max_retries = 0
+
+      pong = ChartMogul::Ping.ping
+      expect(WebMock).to have_requested(:get, "https://api.chartmogul.com/v1/ping")
+      expect(pong.data).to eq('pong!')
+
+      ChartMogul.api_base = 'https://example.chartmogul.com'
+      pong = ChartMogul::Ping.ping
+      expect(WebMock).to have_requested(:get, "https://example.chartmogul.com/v1/ping")
+      expect(pong.data).to eq('pong!')
+    end
+  end
+end

--- a/spec/chartmogul/connection_cache_spec.rb
+++ b/spec/chartmogul/connection_cache_spec.rb
@@ -11,7 +11,6 @@ describe 'Connection cache' do
     to_return(status: 200, body: '{"data":"pong!"}')
   end
 
-
   it 'invalidates the connection and uses new one' do
     VCR.turned_off do
       ChartMogul.account_token = 'dummy-token'

--- a/spec/chartmogul/retry_spec.rb
+++ b/spec/chartmogul/retry_spec.rb
@@ -4,12 +4,13 @@ require 'spec_helper'
 
 describe 'chartmogul retry request' do
   let(:url) { 'https://api.chartmogul.com/v1/customers/search?email=no@email.com' }
+  let(:api_base) { 'https://api.chartmogul.com' }
 
   before do
     Thread.current[ChartMogul::APIResource::THREAD_CONNECTION_KEY] = nil
     config = instance_double(
       'ChartMogul::Configuration', account_token: 'dummy-token',
-                                   secret_key: 'dummy-token', max_retries: max_retries
+                                   secret_key: 'dummy-token', max_retries: max_retries, api_base: api_base
     )
     allow(ChartMogul).to receive(:config).and_return(config)
     stub_const('ChartMogul::APIResource::INTERVAL', 0) # avoid waiting when running specs

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,8 @@ RSpec.configure do |config|
   config.order = 'random'
 
   config.before(:each) do |example|
+    Thread.current[ChartMogul::CONFIG_THREAD_KEY] = nil
+
     if example.metadata[:uses_api]
       ChartMogul.account_token = ENV['TEST_ACCOUNT_TOKEN'] || 'dummy-token'
       ChartMogul.secret_key = ENV['TEST_SECRET_KEY'] || 'dummy-token'


### PR DESCRIPTION
Adds a new configuration attribute `api_base` for overriding default API base endpoint. 
If no value is set it uses `ChartMogul::API_BASE` so existing apps using the client won't be affected. 