### PR TITLE
Upgrade faraday gem [ch20108]

### DIFF
--- a/chartmogul-ruby.gemspec
+++ b/chartmogul-ruby.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables           = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths         = ['lib']
 
-  spec.add_dependency 'faraday', '~> 0.17.3'
+  spec.add_dependency 'faraday', '~> 1.0.0'
 
   spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'pry', '~> 0.12.2'

--- a/lib/chartmogul/api_resource.rb
+++ b/lib/chartmogul/api_resource.rb
@@ -37,7 +37,7 @@ module ChartMogul
 
     def self.handling_errors
       yield
-    rescue Faraday::ClientError => e
+    rescue Faraday::ClientError, Faraday::ServerError => e
       e.response ? handle_request_error(e) : handle_other_error(e)
     rescue StandardError => e
       handle_other_error(e)
@@ -86,7 +86,7 @@ module ChartMogul
         faraday.request :retry, max: ChartMogul.max_retries, retry_statuses: RETRY_STATUSES,
                                 max_interval: MAX_INTERVAL, backoff_factor: BACKOFF_FACTOR,
                                 interval_randomness: INTERVAL_RANDOMNESS, interval: INTERVAL, exceptions: RETRY_EXCEPTIONS
-        faraday.use Faraday::Adapter::NetHttp
+        faraday.adapter Faraday::Adapter::NetHttp
       end
     end
   end


### PR DESCRIPTION
Upgrading faraday gem to `~> 1.0.0` 

In v1 the previous `Faraday::ClientError` has been split for 5xx HTTP Status codes into `Faraday::ServerError`. I've updated error handling for this change. Won't be affecting integrations which use our SDK. 

https://github.com/lostisland/faraday/blob/master/UPGRADING.md#faraday-10