### PR TITLE
Ruby required >= 2.3

### DIFF
--- a/chartmogul-ruby.gemspec
+++ b/chartmogul-ruby.gemspec
@@ -5,20 +5,21 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'chartmogul/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'chartmogul-ruby'
-  spec.version       = ChartMogul::VERSION
-  spec.authors       = ['Petr Kopac']
-  spec.email         = ['petr@chartmogul.com']
+  spec.name                  = 'chartmogul-ruby'
+  spec.version               = ChartMogul::VERSION
+  spec.authors               = ['Petr Kopac']
+  spec.email                 = ['petr@chartmogul.com']
 
-  spec.summary       = 'Chartmogul API Ruby Client'
-  spec.description   = 'Official Ruby client for ChartMogul\'s API'
-  spec.homepage      = 'https://github.com/chartmogul/chartmogul-ruby'
-  spec.license       = 'MIT'
+  spec.summary               = 'Chartmogul API Ruby Client'
+  spec.description           = 'Official Ruby client for ChartMogul\'s API'
+  spec.homepage              = 'https://github.com/chartmogul/chartmogul-ruby'
+  spec.license               = 'MIT'
+  spec.required_ruby_version = '>= 2.3'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ['lib']
+  spec.files                 = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.bindir                = 'exe'
+  spec.executables           = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths         = ['lib']
 
   spec.add_dependency 'faraday', '~> 0.17.3'
 


### PR DESCRIPTION
[Even ruby 2.4 is now at EOL](https://www.ruby-lang.org/en/downloads/branches/), so we can safely enforce it in the gemspec, I think.
![Screenshot from 2020-08-11 13-37-56](https://user-images.githubusercontent.com/5329361/89893004-e387c980-dbd7-11ea-92b6-8d983c38f820.png)
Required version 0 is not true :)