### PR TITLE
Incorrect customer attribute returned by Ruby Gem [ch21317]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /tmp/
 *.swp
 vendor/bundle
+/.idea

--- a/lib/chartmogul/utils/json_parser.rb
+++ b/lib/chartmogul/utils/json_parser.rb
@@ -20,7 +20,15 @@ module ChartMogul
         def opt_string_to_time(value)
           return value unless value.instance_of?(String)
 
-          Time.iso8601(value) rescue Time.rfc2822(value) rescue value
+          parse_timestamp(value)
+        rescue ArgumentError
+          value
+        end
+
+        def parse_timestamp(value)
+          Time.iso8601(value)
+        rescue ArgumentError
+          Time.rfc2822(value)
         end
       end
     end

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ChartMogul
-  VERSION = '1.6.5'
+  VERSION = '1.6.6'
 end

--- a/spec/chartmogul/utils/json_parser_spec.rb
+++ b/spec/chartmogul/utils/json_parser_spec.rb
@@ -14,8 +14,13 @@ describe ChartMogul::Utils::JSONParser do
       expect(result[:attr]).to be_instance_of(Time)
     end
 
-    it "doesn't parse string vaguely looking like a date" do
+    it 'doesn\'t parse string vaguely looking like a date' do
       result = described_class.typecast_custom_attributes(attr: 'May the force be with you.')
+      expect(result[:attr]).to be_instance_of(String)
+    end
+
+    it 'return string if parse of timestamp failed' do
+      result = described_class.typecast_custom_attributes(attr: '2016-02-01T0000:00.000Z')
       expect(result[:attr]).to be_instance_of(String)
     end
   end


### PR DESCRIPTION
I rewrited code that should parse timestamp to ISO8601 and RFC2822 to make it works stable and fallback to string if there is anything other then timestamp. Previous code was buggy.

Ticket URL https://app.clubhouse.io/chartmogul/story/21317/incorrect-customer-attribute-returned-by-ruby-gem

P.S. I can't reproduce bug from ticket.