### PR TITLE
Disable response keys conversion for Customer resource

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # chartmogul-ruby Change Log
 
+## Version 1.6.7 - 8 September 2020
+- Allow adding Customer custom attributes in camel case
+
 ## Version 1.5.0 - 20 February 2020
 - Add support for plan groups API
 

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/adds_custom_attributes.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/adds_custom_attributes.yml
@@ -44,7 +44,7 @@ http_interactions:
     uri: https://api.chartmogul.com/v1/customers/cus_07393ece-aab1-4255-8bcd-0ef11e24b047/attributes/custom
     body:
       encoding: UTF-8
-      string: '{"custom":[{"type":"String","key":"string_key","value":"String Value"},{"type":"Integer","key":"integer_key","value":1234},{"type":"Timestamp","key":"timestamp_key","value":"2016-01-31
+      string: '{"custom":[{"type":"String","key":"StringKey","value":"String Value"},{"type":"Integer","key":"integer_key","value":1234},{"type":"Timestamp","key":"timestamp_key","value":"2016-01-31
         00:00:00 UTC"},{"type":"Boolean","key":"boolean_key","value":true}]}'
     headers:
       User-Agent:
@@ -74,7 +74,7 @@ http_interactions:
       - 'true'
     body:
       encoding: UTF-8
-      string: '{"custom":{"string_key":"String Value","integer_key":1234,"timestamp_key":"2016-01-31T00:00:00.000Z","boolean_key":true}}'
+      string: '{"custom":{"StringKey":"String Value","integer_key":1234,"timestamp_key":"2016-01-31T00:00:00.000Z","boolean_key":true}}'
     http_version:
   recorded_at: Wed, 29 Jun 2016 12:47:09 GMT
 recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/updates_custom_attributes.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/updates_custom_attributes.yml
@@ -45,7 +45,7 @@ http_interactions:
     uri: https://api.chartmogul.com/v1/customers/cus_07393ece-aab1-4255-8bcd-0ef11e24b047/attributes/custom
     body:
       encoding: UTF-8
-      string: '{"custom":{"string_key":"Another String Value","integer_key":5678,"timestamp_key":"2016-02-01
+      string: '{"custom":{"StringKey":"Another String Value","integer_key":5678,"timestamp_key":"2016-02-01
         00:00:00 UTC","boolean_key":false}}'
     headers:
       User-Agent:
@@ -75,7 +75,7 @@ http_interactions:
       - 'true'
     body:
       encoding: UTF-8
-      string: '{"custom":{"string_key":"Another String Value","integer_key":5678,"timestamp_key":"2016-02-01T00:00:00.000Z","boolean_key":false}}'
+      string: '{"custom":{"StringKey":"Another String Value","integer_key":5678,"timestamp_key":"2016-02-01T00:00:00.000Z","boolean_key":false}}'
     http_version:
   recorded_at: Wed, 29 Jun 2016 12:47:09 GMT
 recorded_with: VCR 3.0.3

--- a/lib/chartmogul/api/actions/create.rb
+++ b/lib/chartmogul/api/actions/create.rb
@@ -15,7 +15,7 @@ module ChartMogul
               req.body = JSON.dump(serialize_for_write)
             end
           end
-          json = ChartMogul::Utils::JSONParser.parse(resp.body)
+          json = ChartMogul::Utils::JSONParser.parse(resp.body, skip_case_conversion: self.class.skip_case_conversion)
 
           assign_all_attributes(json)
         end
@@ -30,7 +30,7 @@ module ChartMogul
                 req.body = JSON.dump(resource.serialize_for_write)
               end
             end
-            json = ChartMogul::Utils::JSONParser.parse(resp.body)
+            json = ChartMogul::Utils::JSONParser.parse(resp.body, skip_case_conversion: skip_case_conversion)
 
             new_from_json(json)
           end

--- a/lib/chartmogul/api/actions/custom.rb
+++ b/lib/chartmogul/api/actions/custom.rb
@@ -25,7 +25,7 @@ module ChartMogul
                 req.body = JSON.dump(body_data)
               end
             end
-            ChartMogul::Utils::JSONParser.parse(resp.body)
+            ChartMogul::Utils::JSONParser.parse(resp.body, skip_case_conversion: skip_case_conversion)
           end
 
           def custom!(http_method, http_path, body_data = {})

--- a/lib/chartmogul/api/actions/retrieve.rb
+++ b/lib/chartmogul/api/actions/retrieve.rb
@@ -15,7 +15,7 @@ module ChartMogul
                 req.headers['Content-Type'] = 'application/json'
               end
             end
-            json = ChartMogul::Utils::JSONParser.parse(resp.body)
+            json = ChartMogul::Utils::JSONParser.parse(resp.body, skip_case_conversion: skip_case_conversion)
             new_from_json(json)
           end
         end

--- a/lib/chartmogul/api/actions/update.rb
+++ b/lib/chartmogul/api/actions/update.rb
@@ -15,7 +15,8 @@ module ChartMogul
               req.body = JSON.dump(serialize_for_write)
             end
           end
-          json = ChartMogul::Utils::JSONParser.parse(resp.body)
+
+          json = ChartMogul::Utils::JSONParser.parse(resp.body, skip_case_conversion: self.class.skip_case_conversion)
 
           assign_all_attributes(json)
         end
@@ -30,7 +31,7 @@ module ChartMogul
                 req.body = JSON.dump(resource.serialize_for_write)
               end
             end
-            json = ChartMogul::Utils::JSONParser.parse(resp.body)
+            json = ChartMogul::Utils::JSONParser.parse(resp.body, skip_case_conversion: skip_case_conversion)
 
             new_from_json(json)
           end

--- a/lib/chartmogul/api_resource.rb
+++ b/lib/chartmogul/api_resource.rb
@@ -17,7 +17,7 @@ module ChartMogul
     MAX_INTERVAL = 60
     THREAD_CONNECTION_KEY = 'chartmogul_ruby.api_resource.connection'
 
-    class << self; attr_reader :resource_path, :resource_name, :resource_root_key end
+    class << self; attr_reader :resource_path, :resource_name, :resource_root_key, :skip_case_conversion end
 
     def self.set_resource_path(path)
       @resource_path = ChartMogul::ResourcePath.new(path)
@@ -29,6 +29,11 @@ module ChartMogul
 
     def self.set_resource_root_key(root_key)
       @resource_root_key = root_key
+    end
+
+    # When true, response hash keys won't be converted to snake case
+    def self.set_skip_case_conversion(value)
+      @skip_case_conversion = value
     end
 
     def self.connection

--- a/lib/chartmogul/customer.rb
+++ b/lib/chartmogul/customer.rb
@@ -4,6 +4,7 @@ module ChartMogul
   class Customer < APIResource
     set_resource_name 'Customer'
     set_resource_path '/v1/customers'
+    set_skip_case_conversion true
 
     readonly_attr :uuid
     readonly_attr :id

--- a/lib/chartmogul/utils/json_parser.rb
+++ b/lib/chartmogul/utils/json_parser.rb
@@ -4,8 +4,10 @@ module ChartMogul
   module Utils
     class JSONParser
       class << self
-        def parse(json_string)
+        def parse(json_string, skip_case_conversion: false)
           hash = JSON.parse(json_string, symbolize_names: true)
+          return hash if skip_case_conversion
+
           HashSnakeCaser.new(hash).to_snake_keys
         end
 

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ChartMogul
-  VERSION = '1.6.6'
+  VERSION = '1.6.7'
 end

--- a/spec/chartmogul/customer_spec.rb
+++ b/spec/chartmogul/customer_spec.rb
@@ -210,13 +210,13 @@ describe ChartMogul::Customer do
     it 'adds custom attributes', uses_api: true do
       customer = described_class.retrieve('cus_07393ece-aab1-4255-8bcd-0ef11e24b047')
       customer.add_custom_attributes!(
-        { type: 'String', key: 'string_key', value: 'String Value' },
+        { type: 'String', key: 'StringKey', value: 'String Value' },
         { type: 'Integer', key: 'integer_key', value: 1234 },
         { type: 'Timestamp', key: 'timestamp_key', value: Time.utc(2016, 0o1, 31) },
         type: 'Boolean', key: 'boolean_key', value: true
       )
       expect(customer.custom_attributes).to eq(
-        string_key: 'String Value',
+        StringKey: 'String Value',
         integer_key: 1234,
         timestamp_key: Time.utc(2016, 0o1, 31),
         boolean_key: true
@@ -226,13 +226,13 @@ describe ChartMogul::Customer do
     it 'updates custom attributes', uses_api: true do
       customer = described_class.retrieve('cus_07393ece-aab1-4255-8bcd-0ef11e24b047')
       customer.update_custom_attributes!(
-        string_key: 'Another String Value',
+        StringKey: 'Another String Value',
         integer_key: 5678,
         timestamp_key: Time.utc(2016, 0o2, 1),
         boolean_key: false
       )
       expect(customer.custom_attributes).to eq(
-        string_key: 'Another String Value',
+        StringKey: 'Another String Value',
         integer_key: 5678,
         timestamp_key: Time.utc(2016, 0o2, 1),
         boolean_key: false

--- a/spec/chartmogul/utils/json_parser_spec.rb
+++ b/spec/chartmogul/utils/json_parser_spec.rb
@@ -23,5 +23,11 @@ describe ChartMogul::Utils::JSONParser do
       result = described_class.typecast_custom_attributes(attr: '2016-02-01T0000:00.000Z')
       expect(result[:attr]).to be_instance_of(String)
     end
+
+    it 'allows skipping camel case conversion' do
+      json = {'aKey': 'a_value', 'bKey': 'b_value'}.to_json
+      result = described_class.parse(json, skip_case_conversion: true)
+      expect(result.keys).to contain_exactly(:aKey,:bKey)
+    end
   end
 end


### PR DESCRIPTION
Previously all response keys were converted to snake case by default. This meant that if response returns {"Summary": {...}} as json, it would be converted to {summary: {}} ruby Hash. Presumably this functionality was added to uniformly set instance attributes.
This doesn't completely work for Customer. Customer resource allows setting custom attributes via `add_custom_attributes!`. A user can pass and arbitrary key. However, if a camel case attribute is passed (e.g. `CustomField`) it will be converted to a snake case (`custom_field`) and set to the `custom_attributes` hash of the instance. Therefore the next call to `update!` method will fail because the server is not able to match custom attributes with different cases (`custom_field` with `CustomField`).

This PR fixes the problem by disabling snake case conversion for Customer resource.