### PR TITLE
Clean up tokens from library [ch27130]

### DIFF
--- a/fixtures/vcr_cassettes/ChartMogul_APIResource/connection/works_in_a_threaded_environment.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_APIResource/connection/works_in_a_threaded_environment.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic aW52YWxpZDppbnZhbGlk
+      - Basic hidden
   response:
     status:
       code: 401
@@ -47,7 +47,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ZHVtbXktdG9rZW46ZHVtbXktdG9rZW4=
+      - Basic hidden
   response:
     status:
       code: 200
@@ -86,7 +86,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic aW52YWxpZDppbnZhbGlk
+      - Basic hidden
   response:
     status:
       code: 401

--- a/fixtures/vcr_cassettes/ChartMogul_APIResource/connection/works_when_credentials_are_updated.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_APIResource/connection/works_when_credentials_are_updated.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic aW52YWxpZDppbnZhbGlk
+      - Basic hidden
   response:
     status:
       code: 401
@@ -47,7 +47,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ZHVtbXktdG9rZW46ZHVtbXktdG9rZW4=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/adds_custom_attributes.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/adds_custom_attributes.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/adds_required_tags.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/adds_required_tags.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200
@@ -51,7 +51,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/can_page_through_search_endpoint.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/can_page_through_search_endpoint.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/correctly_handles_a_422_response.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/correctly_handles_a_422_response.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 422

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/correctly_interracts_with_the_API.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/correctly_interracts_with_the_API.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -63,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -113,7 +113,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 200
@@ -161,7 +161,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 204
@@ -204,7 +204,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/merges_customers.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/merges_customers.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200
@@ -49,7 +49,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200
@@ -86,7 +86,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 202
@@ -121,7 +121,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 404
@@ -157,7 +157,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/raises_401_if_invalid_credentials.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/raises_401_if_invalid_credentials.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ZHVtbXktdG9rZW46ZHVtbXktdG9rZW4=
+      - Basic hidden
   response:
     status:
       code: 401

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/raises_404_if_no_customers_found.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/raises_404_if_no_customers_found.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 404

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/raises_422_for_update_with_invalid_data.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/raises_422_for_update_with_invalid_data.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200
@@ -59,7 +59,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic eGdKZWFVUDNhY3lCV1NIQkxuVmFHdzplMTdiMGY5ZTkyMmZiNjJlOTI0YmNhYTcwYmUyOTBmOQ==
+      - Basic hidden
   response:
     status:
       code: 422

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/removes_custom_attributes.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/removes_custom_attributes.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/removes_tags.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/removes_tags.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/respects_camel_case_for_all_customers_endpoint.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/respects_camel_case_for_all_customers_endpoint.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic <SECRET>
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/returns_all_customers_through_list_all_endpoint.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/returns_all_customers_through_list_all_endpoint.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/returns_customer_through_retrieve_endpoint.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/returns_customer_through_retrieve_endpoint.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/returns_right_customers_through_search_endpoint.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/returns_right_customers_through_search_endpoint.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/updates_custom_attributes.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/updates_custom_attributes.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200
@@ -53,7 +53,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/updates_customer.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/updates_customer.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200
@@ -60,7 +60,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200
@@ -104,7 +104,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/updates_customer_using_class_method.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/updates_customer_using_class_method.yml
@@ -14,7 +14,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      - Basic hidden
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/_find_by_external_id/when_external_id_is_provided/returns_matching_user_if_exists.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/_find_by_external_id/when_external_id_is_provided/returns_matching_user_if_exists.yml
@@ -13,7 +13,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -61,7 +61,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/_find_by_external_id/when_external_id_is_provided/returns_nil_if_customer_does_not_exist.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/_find_by_external_id/when_external_id_is_provided/returns_nil_if_customer_does_not_exist.yml
@@ -13,7 +13,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -61,7 +61,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_CustomerInvoices/API_Interactions/correctly_interracts_with_the_API.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_CustomerInvoices/API_Interactions/correctly_interracts_with_the_API.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -50,7 +50,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -89,7 +89,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -146,7 +146,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      - Basic hidden
   response:
     status:
       code: 200
@@ -209,7 +209,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -264,7 +264,7 @@ http_interactions:
       User-Agent:
       - Faraday v1.0.1
       Authorization:
-      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      - Basic hidden
   response:
     status:
       code: 204
@@ -313,7 +313,7 @@ http_interactions:
       User-Agent:
       - Faraday v1.0.1
       Authorization:
-      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      - Basic hidden
   response:
     status:
       code: 204

--- a/fixtures/vcr_cassettes/ChartMogul_DataSource/API_Interactions/correctly_interracts_with_the_API.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_DataSource/API_Interactions/correctly_interracts_with_the_API.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ZTk5MGJkMjNmNTQzYWNjZGY3ZDg4Yjk2OWNiMzAwOWI6NWM4YThlY2UxMTFmYmE4NTE1MGVmNzBjYmZmM2I3ZWI=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -60,7 +60,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - Basic ZTk5MGJkMjNmNTQzYWNjZGY3ZDg4Yjk2OWNiMzAwOWI6NWM4YThlY2UxMTFmYmE4NTE1MGVmNzBjYmZmM2I3ZWI=
+      - Basic hidden
   response:
     status:
       code: 200
@@ -108,7 +108,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - Basic ZTk5MGJkMjNmNTQzYWNjZGY3ZDg4Yjk2OWNiMzAwOWI6NWM4YThlY2UxMTFmYmE4NTE1MGVmNzBjYmZmM2I3ZWI=
+      - Basic hidden
   response:
     status:
       code: 204
@@ -149,7 +149,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - Basic ZTk5MGJkMjNmNTQzYWNjZGY3ZDg4Yjk2OWNiMzAwOWI6NWM4YThlY2UxMTFmYmE4NTE1MGVmNzBjYmZmM2I3ZWI=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_DataSource/API_Interactions/correctly_raises_errors_on_404.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_DataSource/API_Interactions/correctly_raises_errors_on_404.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - Basic ZTk5MGJkMjNmNTQzYWNjZGY3ZDg4Yjk2OWNiMzAwOWI6NWM4YThlY2UxMTFmYmE4NTE1MGVmNzBjYmZmM2I3ZWI=
+      - Basic hidden
   response:
     status:
       code: 404

--- a/fixtures/vcr_cassettes/ChartMogul_DataSource/API_Interactions/correctly_raises_errors_on_422.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_DataSource/API_Interactions/correctly_raises_errors_on_422.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ZTk5MGJkMjNmNTQzYWNjZGY3ZDg4Yjk2OWNiMzAwOWI6NWM4YThlY2UxMTFmYmE4NTE1MGVmNzBjYmZmM2I3ZWI=
+      - Basic hidden
   response:
     status:
       code: 422

--- a/fixtures/vcr_cassettes/ChartMogul_DataSource/API_Interactions/retrieves_existing_data_source_matching_uuid.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_DataSource/API_Interactions/retrieves_existing_data_source_matching_uuid.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ZHVtbXktdG9rZW46ZHVtbXktdG9rZW4=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -61,7 +61,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ZHVtbXktdG9rZW46ZHVtbXktdG9rZW4=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Invoice/API_Interactions/deletes_an_invoice.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Invoice/API_Interactions/deletes_an_invoice.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 204

--- a/fixtures/vcr_cassettes/ChartMogul_Invoice/API_Interactions/deletes_an_invoice_with_class_method.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Invoice/API_Interactions/deletes_an_invoice_with_class_method.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 204

--- a/fixtures/vcr_cassettes/ChartMogul_Invoice/API_Interactions/raises_error_on_deleting_non-existing_invoice.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Invoice/API_Interactions/raises_error_on_deleting_non-existing_invoice.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 404

--- a/fixtures/vcr_cassettes/ChartMogul_Invoice/API_Interactions/retrieves_existing_invoice_by_uuid.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Invoice/API_Interactions/retrieves_existing_invoice_by_uuid.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Invoice/API_Interactions/returns_all_invoices_through_list_all_endpoint.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Invoice/API_Interactions/returns_all_invoices_through_list_all_endpoint.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic MDFiNzI2YzI0ZjNiYjhlOTc0MmEwNGZiMDhhZmE3NzQ6NzJlNGMxYTdlZTFiYzlkNGZjMDBlZWUwNWIyN2QzMGY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_ARPA/behaves_like_Metrics_API_resource/behaves_like_Summary/should_have_summary.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_ARPA/behaves_like_Metrics_API_resource/behaves_like_Summary/should_have_summary.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_ARPA/behaves_like_Metrics_API_resource/should_have_entries.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_ARPA/behaves_like_Metrics_API_resource/should_have_entries.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_ARR/behaves_like_Metrics_API_resource/behaves_like_Summary/should_have_summary.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_ARR/behaves_like_Metrics_API_resource/behaves_like_Summary/should_have_summary.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_ARR/behaves_like_Metrics_API_resource/should_have_entries.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_ARR/behaves_like_Metrics_API_resource/should_have_entries.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_ASP/behaves_like_Metrics_API_resource/behaves_like_Summary/should_have_summary.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_ASP/behaves_like_Metrics_API_resource/behaves_like_Summary/should_have_summary.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_ASP/behaves_like_Metrics_API_resource/should_have_entries.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_ASP/behaves_like_Metrics_API_resource/should_have_entries.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_Activity/behaves_like_Pageable/should_be_pageable.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_Activity/behaves_like_Pageable/should_be_pageable.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_Activity/should_have_Activity_entries.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_Activity/should_have_Activity_entries.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_AllKeyMetric/should_have_entries.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_AllKeyMetric/should_have_entries.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_CustomerChurnRate/behaves_like_Metrics_API_resource/behaves_like_Summary/should_have_summary.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_CustomerChurnRate/behaves_like_Metrics_API_resource/behaves_like_Summary/should_have_summary.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_CustomerChurnRate/behaves_like_Metrics_API_resource/should_have_entries.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_CustomerChurnRate/behaves_like_Metrics_API_resource/should_have_entries.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_CustomerCount/behaves_like_Metrics_API_resource/behaves_like_Summary/should_have_summary.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_CustomerCount/behaves_like_Metrics_API_resource/behaves_like_Summary/should_have_summary.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_CustomerCount/behaves_like_Metrics_API_resource/should_have_entries.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_CustomerCount/behaves_like_Metrics_API_resource/should_have_entries.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_LTV/behaves_like_Metrics_API_resource/behaves_like_Summary/should_have_summary.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_LTV/behaves_like_Metrics_API_resource/behaves_like_Summary/should_have_summary.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_LTV/behaves_like_Metrics_API_resource/should_have_entries.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_LTV/behaves_like_Metrics_API_resource/should_have_entries.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_MRR/behaves_like_Summary/should_have_summary.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_MRR/behaves_like_Summary/should_have_summary.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_MRR/should_have_entries.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_MRR/should_have_entries.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_MRRChurnRate/behaves_like_Metrics_API_resource/behaves_like_Summary/should_have_summary.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_MRRChurnRate/behaves_like_Metrics_API_resource/behaves_like_Summary/should_have_summary.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_MRRChurnRate/behaves_like_Metrics_API_resource/should_have_entries.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_MRRChurnRate/behaves_like_Metrics_API_resource/should_have_entries.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_Subscription/behaves_like_Pageable/should_be_pageable.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_Subscription/behaves_like_Pageable/should_be_pageable.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_Subscription/should_have_Subscription_entries.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_Subscription/should_have_Subscription_entries.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YzU0NjYwNDU5ZTMzODBkYzUyNmVhYjNiZjlhZGIyOGQ6N2MyMDEzOTYzZjQ2NGZiMmQ3ZjVjOTJkZDZiMjk2NDQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Ping/pings/and_fails_on_incorrect_credentials.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Ping/pings/and_fails_on_incorrect_credentials.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ZHVtbXktdG9rZW46ZHVtbXktdG9rZW4=
+      - Basic hidden
   response:
     status:
       code: 401

--- a/fixtures/vcr_cassettes/ChartMogul_Ping/pings/and_fails_with_500_internal_server_error.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Ping/pings/and_fails_with_500_internal_server_error.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ZHVtbXktdG9rZW46ZHVtbXktdG9rZW4=
+      - Basic hidden
   response:
     status:
       code: 500

--- a/fixtures/vcr_cassettes/ChartMogul_Ping/pings/and_fails_with_504_gateway_timeout_error.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Ping/pings/and_fails_with_504_gateway_timeout_error.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ZHVtbXktdG9rZW46ZHVtbXktdG9rZW4=
+      - Basic hidden
   response:
     status:
       code: 504

--- a/fixtures/vcr_cassettes/ChartMogul_Ping/pings/when_credentials_correct.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Ping/pings/when_credentials_correct.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ZHVtbXktdG9rZW46ZHVtbXktdG9rZW4=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Plan/API_Interactions/correctly_handles_a_422_error.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Plan/API_Interactions/correctly_handles_a_422_error.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 422

--- a/fixtures/vcr_cassettes/ChartMogul_Plan/API_Interactions/correctly_interacts_with_the_API.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Plan/API_Interactions/correctly_interacts_with_the_API.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -63,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -111,7 +111,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Plan/API_Interactions/deletes_existing_plan.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Plan/API_Interactions/deletes_existing_plan.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ZHVtbXktdG9rZW46ZHVtbXktdG9rZW4=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -63,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -111,7 +111,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 404
@@ -158,7 +158,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 204

--- a/fixtures/vcr_cassettes/ChartMogul_Plan/API_Interactions/retrieves_existing_plan_by_uuid.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Plan/API_Interactions/retrieves_existing_plan_by_uuid.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ZHVtbXktdG9rZW46ZHVtbXktdG9rZW4=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -63,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -111,7 +111,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Plan/API_Interactions/updates_existing_plan.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Plan/API_Interactions/updates_existing_plan.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ZHVtbXktdG9rZW46ZHVtbXktdG9rZW4=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -63,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -111,7 +111,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 200
@@ -158,7 +158,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - Basic ODE2MjZkMWFiMzU5NTIwMzY5MjhjNjJjYmJiNDMyN2M6ODY3MDRmMDdkYzQwZmYzYjYyYzRjY2E5OTYxMjk2MzY=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Plan/API_Interactions/updates_existing_plan_using_class_method.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Plan/API_Interactions/updates_existing_plan_using_class_method.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      - Basic hidden
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -54,7 +54,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      - Basic hidden
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -115,7 +115,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      - Basic hidden
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:

--- a/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/correctly_handles_a_422_error.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/correctly_handles_a_422_error.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 422

--- a/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/deletes_a_plan_group.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/deletes_a_plan_group.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -50,7 +50,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -102,7 +102,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -154,7 +154,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 200
@@ -207,7 +207,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 204
@@ -252,7 +252,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 404

--- a/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/retrieves_existing_plan_group_by_uuid.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/retrieves_existing_plan_group_by_uuid.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -50,7 +50,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -102,7 +102,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -154,7 +154,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 200
@@ -207,7 +207,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/returns_an_array_of_plan_groups.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/returns_an_array_of_plan_groups.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -50,7 +50,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -102,7 +102,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -154,7 +154,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 200
@@ -207,7 +207,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -259,7 +259,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 200
@@ -312,7 +312,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/updates_existing_plan_group_name.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/updates_existing_plan_group_name.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -50,7 +50,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -102,7 +102,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -154,7 +154,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 200
@@ -207,7 +207,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 200
@@ -260,7 +260,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/updates_existing_plan_group_name_via_class_method.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/updates_existing_plan_group_name_via_class_method.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      - Basic hidden
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -54,7 +54,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      - Basic hidden
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -116,7 +116,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      - Basic hidden
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -178,7 +178,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      - Basic hidden
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -242,7 +242,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YjNjZTUxNTNkMDYyNmQwNjE3YWQ4OWQyMzQ2OTA1OTc6OGE0YTgyOTMwYTVhMjgzOTA3MDgwNGYzMTdmNTZjYjA=
+      - Basic hidden
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:

--- a/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/updates_existing_plan_group_plans.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_PlanGroup/API_interactions/updates_existing_plan_group_plans.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -50,7 +50,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -102,7 +102,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -154,7 +154,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -206,7 +206,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 200
@@ -259,7 +259,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 200
@@ -312,7 +312,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 200
@@ -365,7 +365,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_PlanGroups_Plans/API_interactions/given_a_plan_group_uuid_returns_an_array_of_plans_in_the_plan_group.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_PlanGroups_Plans/API_interactions/given_a_plan_group_uuid_returns_an_array_of_plans_in_the_plan_group.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic OGIzNjcyOWUzMmU1OWJiMTBlNjEwZWZiOWFhNjExZTA6Nzg0MWEyNWU4Y2VkMmZjOGRmYzFhZGU3YWM0ZmFjZTQ=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -50,7 +50,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic OGIzNjcyOWUzMmU1OWJiMTBlNjEwZWZiOWFhNjExZTA6Nzg0MWEyNWU4Y2VkMmZjOGRmYzFhZGU3YWM0ZmFjZTQ=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -102,7 +102,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic OGIzNjcyOWUzMmU1OWJiMTBlNjEwZWZiOWFhNjExZTA6Nzg0MWEyNWU4Y2VkMmZjOGRmYzFhZGU3YWM0ZmFjZTQ=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -154,7 +154,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic OGIzNjcyOWUzMmU1OWJiMTBlNjEwZWZiOWFhNjExZTA6Nzg0MWEyNWU4Y2VkMmZjOGRmYzFhZGU3YWM0ZmFjZTQ=
+      - Basic hidden
   response:
     status:
       code: 200
@@ -207,7 +207,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic OGIzNjcyOWUzMmU1OWJiMTBlNjEwZWZiOWFhNjExZTA6Nzg0MWEyNWU4Y2VkMmZjOGRmYzFhZGU3YWM0ZmFjZTQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Subscription/API_Interactions/connects_subscriptions.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Subscription/API_Interactions/connects_subscriptions.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -50,7 +50,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -89,7 +89,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -141,7 +141,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -196,7 +196,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 201
@@ -245,7 +245,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 200
@@ -296,7 +296,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 202
@@ -341,7 +341,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 202
@@ -376,7 +376,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 200
@@ -412,7 +412,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.15.4
       Authorization:
-      - Basic secret
+      - Basic hidden
   response:
     status:
       code: 204

--- a/fixtures/vcr_cassettes/ChartMogul_Subscription/API_Interactions/correctly_interracts_with_the_API.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Subscription/API_Interactions/correctly_interracts_with_the_API.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YmIzN2I0Njk5NjNlMjhlYjY2MjA1ZWYzZmU1MWQ1NmM6ZmM1YjQxYzM3YTNlZTcwYjQyN2UwYzU1ODg2NzA2ZmQ=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -63,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YmIzN2I0Njk5NjNlMjhlYjY2MjA1ZWYzZmU1MWQ1NmM6ZmM1YjQxYzM3YTNlZTcwYjQyN2UwYzU1ODg2NzA2ZmQ=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -114,7 +114,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YmIzN2I0Njk5NjNlMjhlYjY2MjA1ZWYzZmU1MWQ1NmM6ZmM1YjQxYzM3YTNlZTcwYjQyN2UwYzU1ODg2NzA2ZmQ=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -165,7 +165,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YmIzN2I0Njk5NjNlMjhlYjY2MjA1ZWYzZmU1MWQ1NmM6ZmM1YjQxYzM3YTNlZTcwYjQyN2UwYzU1ODg2NzA2ZmQ=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -214,7 +214,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YmIzN2I0Njk5NjNlMjhlYjY2MjA1ZWYzZmU1MWQ1NmM6ZmM1YjQxYzM3YTNlZTcwYjQyN2UwYzU1ODg2NzA2ZmQ=
+      - Basic hidden
   response:
     status:
       code: 200
@@ -263,7 +263,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YmIzN2I0Njk5NjNlMjhlYjY2MjA1ZWYzZmU1MWQ1NmM6ZmM1YjQxYzM3YTNlZTcwYjQyN2UwYzU1ODg2NzA2ZmQ=
+      - Basic hidden
   response:
     status:
       code: 202
@@ -306,7 +306,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       Authorization:
-      - Basic YmIzN2I0Njk5NjNlMjhlYjY2MjA1ZWYzZmU1MWQ1NmM6ZmM1YjQxYzM3YTNlZTcwYjQyN2UwYzU1ODg2NzA2ZmQ=
+      - Basic hidden
   response:
     status:
       code: 204

--- a/fixtures/vcr_cassettes/ChartMogul_Subscription/API_Interactions/has_multiple_aliases.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Subscription/API_Interactions/has_multiple_aliases.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YmIzN2I0Njk5NjNlMjhlYjY2MjA1ZWYzZmU1MWQ1NmM6ZmM1YjQxYzM3YTNlZTcwYjQyN2UwYzU1ODg2NzA2ZmQ=
+      - Basic hidden
   response:
     status:
       code: 200
@@ -61,7 +61,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YmIzN2I0Njk5NjNlMjhlYjY2MjA1ZWYzZmU1MWQ1NmM6ZmM1YjQxYzM3YTNlZTcwYjQyN2UwYzU1ODg2NzA2ZmQ=
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Subscription/_update_cancellation_dates/when_array_has_time_objects/is_setting_the_cancellation_dates_of_the_subscription.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Subscription/_update_cancellation_dates/when_array_has_time_objects/is_setting_the_cancellation_dates_of_the_subscription.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic Hidden
+      - Basic hidden
   response:
     status:
       code: 200
@@ -51,7 +51,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic Hidden
+      - Basic hidden
   response:
     status:
       code: 200
@@ -102,7 +102,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic Hidden
+      - Basic hidden
   response:
     status:
       code: 202

--- a/fixtures/vcr_cassettes/ChartMogul_Subscription/_update_cancellation_dates/when_array_includes_invalid_entries/raises_an_exception.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Subscription/_update_cancellation_dates/when_array_includes_invalid_entries/raises_an_exception.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic Hidden
+      - Basic hidden
   response:
     status:
       code: 200
@@ -51,7 +51,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic Hidden
+      - Basic hidden
   response:
     status:
       code: 200

--- a/fixtures/vcr_cassettes/ChartMogul_Subscription/_update_cancellation_dates/when_array_includes_valid_entries/is_setting_the_cancellation_dates_of_the_subscription.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Subscription/_update_cancellation_dates/when_array_includes_valid_entries/is_setting_the_cancellation_dates_of_the_subscription.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic Hidden
+      - Basic hidden
   response:
     status:
       code: 200
@@ -51,7 +51,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic Hidden
+      - Basic hidden
   response:
     status:
       code: 200
@@ -102,7 +102,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic Mjk5ZjAyMjYzMDRkNThhNWZiYzFlNTcwOTdlZGU3Mjk6OWM4NWIwNGFkN2FjNzE2NTUwYTY1NjZhZWYwYzM5ZmU=
+      - Basic hidden
   response:
     status:
       code: 202

--- a/fixtures/vcr_cassettes/ChartMogul_Subscription/_update_cancellation_dates/when_array_is_empty/makes_an_API_call_and_removes_the_cancellation_dates.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Subscription/_update_cancellation_dates/when_array_is_empty/makes_an_API_call_and_removes_the_cancellation_dates.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic Hidden
+      - Basic hidden
   response:
     status:
       code: 200
@@ -51,7 +51,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic Hidden
+      - Basic hidden
   response:
     status:
       code: 200
@@ -102,7 +102,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic Mjk5ZjAyMjYzMDRkNThhNWZiYzFlNTcwOTdlZGU3Mjk6OWM4NWIwNGFkN2FjNzE2NTUwYTY1NjZhZWYwYzM5ZmU=
+      - Basic hidden
   response:
     status:
       code: 202

--- a/fixtures/vcr_cassettes/ChartMogul_Transactions_Payment/API_Interactions/correctly_interracts_with_the_API.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Transactions_Payment/API_Interactions/correctly_interracts_with_the_API.yml
@@ -12,7 +12,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YmIzN2I0Njk5NjNlMjhlYjY2MjA1ZWYzZmU1MWQ1NmM6ZmM1YjQxYzM3YTNlZTcwYjQyN2UwYzU1ODg2NzA2ZmQ=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -63,7 +63,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YmIzN2I0Njk5NjNlMjhlYjY2MjA1ZWYzZmU1MWQ1NmM6ZmM1YjQxYzM3YTNlZTcwYjQyN2UwYzU1ODg2NzA2ZmQ=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -113,7 +113,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YmIzN2I0Njk5NjNlMjhlYjY2MjA1ZWYzZmU1MWQ1NmM6ZmM1YjQxYzM3YTNlZTcwYjQyN2UwYzU1ODg2NzA2ZmQ=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -162,7 +162,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - Basic YmIzN2I0Njk5NjNlMjhlYjY2MjA1ZWYzZmU1MWQ1NmM6ZmM1YjQxYzM3YTNlZTcwYjQyN2UwYzU1ODg2NzA2ZmQ=
+      - Basic hidden
   response:
     status:
       code: 201
@@ -209,7 +209,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.2
       Authorization:
-      - Basic YmIzN2I0Njk5NjNlMjhlYjY2MjA1ZWYzZmU1MWQ1NmM6ZmM1YjQxYzM3YTNlZTcwYjQyN2UwYzU1ODg2NzA2ZmQ=
+      - Basic hidden
   response:
     status:
       code: 204

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,9 @@ VCR.configure do |config|
   config.cassette_library_dir = 'fixtures/vcr_cassettes'
   config.hook_into :faraday
   config.configure_rspec_metadata!
+  config.filter_sensitive_data('Basic hidden') do |interaction|
+    interaction.request.headers['Authorization'].first # returns an array
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
We should not save these tokens, like we don't in other public libraries. Replicability can be ensured if each test case submits its data first.
I am also adding automated cleanup of Authorization header on VCR.