### PR TITLE
Provide immutable keys for custom attributes [ch28502]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # chartmogul-ruby Change Log
 
+## Version 1.7.2 - 16 March 2021
+- Fix bug preventing instantiating attributes on ChartMogul::Customers objects
+
+## Version 1.7.1 - 8 March 2021
+- Adds amount_in_cents to payment for partial payments
+- Adds account API endpoint
+
 ## Version 1.6.9 - 10 December 2020
 - Fix ChartMogul::Customers class
 

--- a/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/correctly_interracts_with_the_API.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Customer/API_Interactions/correctly_interracts_with_the_API.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: '{"name":"Customer Test Data Source"}'
     headers:
       User-Agent:
-      - Faraday v0.9.2
+      - Faraday v1.0.1
       Content-Type:
       - application/json
       Authorization:
@@ -16,50 +16,38 @@ http_interactions:
   response:
     status:
       code: 201
-      message:
+      message: Created
     headers:
       server:
       - nginx/1.10.1
       date:
-      - Tue, 08 Nov 2016 08:57:33 GMT
+      - Tue, 16 Mar 2021 12:27:18 GMT
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       transfer-encoding:
       - chunked
       connection:
-      - close
-      x-frame-options:
-      - SAMEORIGIN
-      x-xss-protection:
-      - 1; mode=block
-      x-content-type-options:
-      - nosniff
-      etag:
-      - W/"bcfee5f9180970835929930b05411ff4"
-      cache-control:
-      - max-age=0, private, must-revalidate
-      x-request-id:
-      - 9505cefe-9a7a-46af-a173-7a686cf46800
-      x-runtime:
-      - '0.461858'
-      strict-transport-security:
-      - max-age=15768000
+      - keep-alive
+      status:
+      - 201 Created
+      access-control-allow-credentials:
+      - 'true'
     body:
       encoding: UTF-8
-      string: '{"uuid":"ds_632433ee-a591-11e6-aa29-ff9ccc9a74aa","name":"Customer
-        Test Data Source","created_at":"2016-11-08T08:57:33.304Z","status":"never_imported"}'
+      string: '{"uuid":"ds_f2f67ad0-8652-11eb-a9f8-37471a677085","name":"Customer
+        Test Data Source","system":"Import API","created_at":"2021-03-16T12:27:18.630Z","status":"idle"}'
     http_version:
-  recorded_at: Tue, 08 Nov 2016 08:57:33 GMT
+  recorded_at: Tue, 16 Mar 2021 12:27:18 GMT
 - request:
     method: post
     uri: https://api.chartmogul.com/v1/customers
     body:
       encoding: UTF-8
-      string: '{"external_id":"X1234","name":"Test Customer","email":"test@example.com","country":"DE","city":"Berlin","data_source_uuid":"ds_632433ee-a591-11e6-aa29-ff9ccc9a74aa","lead_created_at":"2016-10-01
+      string: '{"external_id":"X1234","name":"Test Customer","email":"test@example.com","country":"DE","city":"Berlin","data_source_uuid":"ds_f2f67ad0-8652-11eb-a9f8-37471a677085","lead_created_at":"2016-10-01
         23:55:00 UTC","free_trial_started_at":"2016-10-12 11:12:00 UTC"}'
     headers:
       User-Agent:
-      - Faraday v0.9.2
+      - Faraday v1.0.1
       Content-Type:
       - application/json
       Authorization:
@@ -67,40 +55,29 @@ http_interactions:
   response:
     status:
       code: 201
-      message:
+      message: Created
     headers:
       server:
       - nginx/1.10.1
       date:
-      - Tue, 08 Nov 2016 08:57:33 GMT
+      - Tue, 16 Mar 2021 12:27:19 GMT
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       transfer-encoding:
       - chunked
       connection:
-      - close
-      x-frame-options:
-      - SAMEORIGIN
-      x-xss-protection:
-      - 1; mode=block
-      x-content-type-options:
-      - nosniff
-      etag:
-      - W/"edb1e5e3324d47803eccb229a21363df"
-      cache-control:
-      - max-age=0, private, must-revalidate
-      x-request-id:
-      - bf049e2c-b057-4d90-85bf-f90c9ca98b31
-      x-runtime:
-      - '0.158973'
-      strict-transport-security:
-      - max-age=15768000
+      - keep-alive
+      status:
+      - 201 Created
+      access-control-allow-credentials:
+      - 'true'
     body:
       encoding: UTF-8
-      string: '{"uuid":"cus_709bf73d-dc7c-4fb3-825d-a32c7fe5be16","external_id":"X1234","name":"Test
-        Customer","company":"","email":"test@example.com","city":"Berlin","state":"","country":"DE","zip":"","lead_created_at":"2016-10-01T23:55:00.000Z","free_trial_started_at":"2016-10-12T11:12:00.000Z","data_source_uuid":"ds_632433ee-a591-11e6-aa29-ff9ccc9a74aa"}'
+      string: '{"id":93760512,"uuid":"cus_f340970a-8652-11eb-a9f8-cfc7971a103f","external_id":"X1234","name":"Test
+        Customer","email":"test@example.com","status":"Lead","customer-since":null,"attributes":{"custom":{},"clearbit":{},"stripe":{},"tags":[]},"data_source_uuid":"ds_f2f67ad0-8652-11eb-a9f8-37471a677085","data_source_uuids":["ds_f2f67ad0-8652-11eb-a9f8-37471a677085"],"external_ids":["X1234"],"company":"","country":"DE","state":null,"city":"Berlin","zip":null,"lead_created_at":"2016-10-01T23:55:00.000Z","free_trial_started_at":"2016-10-12T11:12:00.000Z","address":{"country":"Germany","state":null,"city":"Berlin","address_zip":null},"mrr":0,"arr":0,"billing-system-url":null,"chartmogul-url":"https://app.chartmogul.com/#customers/93760512-Test_Customer","billing-system-type":"Import
+        API","currency":"USD","currency-sign":"$"}'
     http_version:
-  recorded_at: Tue, 08 Nov 2016 08:57:33 GMT
+  recorded_at: Tue, 16 Mar 2021 12:27:19 GMT
 - request:
     method: get
     uri: https://api.chartmogul.com/v1/customers
@@ -109,7 +86,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.9.2
+      - Faraday v1.0.1
       Content-Type:
       - application/json
       Authorization:
@@ -117,81 +94,62 @@ http_interactions:
   response:
     status:
       code: 200
-      message:
+      message: OK
     headers:
       server:
       - nginx/1.10.1
       date:
-      - Tue, 08 Nov 2016 08:57:34 GMT
+      - Tue, 16 Mar 2021 12:27:19 GMT
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       transfer-encoding:
       - chunked
       connection:
-      - close
-      x-frame-options:
-      - SAMEORIGIN
-      x-xss-protection:
-      - 1; mode=block
-      x-content-type-options:
-      - nosniff
-      etag:
-      - W/"eb861872d3bd01a055485e96ccf38898"
-      cache-control:
-      - max-age=0, private, must-revalidate
-      x-request-id:
-      - 32f87d7c-f944-405d-a87c-2195f175940a
-      x-runtime:
-      - '0.022802'
-      strict-transport-security:
-      - max-age=15768000
+      - keep-alive
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      access-control-allow-credentials:
+      - 'true'
     body:
-      encoding: UTF-8
-      string: '{"entries":[{"uuid":"cus_709bf73d-dc7c-4fb3-825d-a32c7fe5be16","external_id":"X1234","name":"Test
-        Customer","company":"","email":"test@example.com","city":"Berlin","state":"","country":"DE","zip":"","lead_created_at":"2016-10-01T23:55:00.000Z","free_trial_started_at":"2016-10-12T11:12:00.000Z","data_source_uuid":"ds_632433ee-a591-11e6-aa29-ff9ccc9a74aa"}],"current_page":1,"total_pages":1,"has_more":false,"per_page":50,"page":1}'
+      encoding: ASCII-8BIT
+      string: '{"entries":[{"id":93760512,"uuid":"cus_f340970a-8652-11eb-a9f8-cfc7971a103f","external_id":"X1234","name":"Test
+        Customer","email":"test@example.com","status":"Lead","customer-since":null,"attributes":{"custom":{},"clearbit":{},"stripe":{},"tags":[]},"data_source_uuid":"ds_f2f67ad0-8652-11eb-a9f8-37471a677085","data_source_uuids":["ds_f2f67ad0-8652-11eb-a9f8-37471a677085"],"external_ids":["X1234"],"company":"","country":"DE","state":null,"city":"Berlin","zip":null,"lead_created_at":"2016-10-01T23:55:00.000Z","free_trial_started_at":"2016-10-12T11:12:00.000Z","address":{"country":"Germany","state":null,"city":"Berlin","address_zip":null},"mrr":0,"arr":0,"billing-system-url":null,"chartmogul-url":"https://app.chartmogul.com/#customers/93760512-Test_Customer","billing-system-type":"Import
+        API","currency":"USD","currency-sign":"$"}],"current_page":1,"total_pages":1,"has_more":false,"per_page":200,"page":1}'
     http_version:
-  recorded_at: Tue, 08 Nov 2016 08:57:34 GMT
+  recorded_at: Tue, 16 Mar 2021 12:27:19 GMT
 - request:
     method: delete
-    uri: https://api.chartmogul.com/v1/customers/cus_709bf73d-dc7c-4fb3-825d-a32c7fe5be16
+    uri: https://api.chartmogul.com/v1/customers/cus_f340970a-8652-11eb-a9f8-cfc7971a103f
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.9.2
+      - Faraday v1.0.1
       Authorization:
       - Basic hidden
   response:
     status:
       code: 204
-      message:
+      message: No Content
     headers:
       server:
       - nginx/1.10.1
       date:
-      - Tue, 08 Nov 2016 08:57:34 GMT
+      - Tue, 16 Mar 2021 12:28:19 GMT
       connection:
-      - close
-      x-frame-options:
-      - SAMEORIGIN
-      x-xss-protection:
-      - 1; mode=block
-      x-content-type-options:
-      - nosniff
-      cache-control:
-      - no-cache
-      x-request-id:
-      - f163488f-bbea-4937-897b-ee08b69a4560
-      x-runtime:
-      - '0.015696'
-      strict-transport-security:
-      - max-age=15768000
+      - keep-alive
+      status:
+      - 204 No Content
+      access-control-allow-credentials:
+      - 'true'
     body:
       encoding: UTF-8
       string: ''
     http_version:
-  recorded_at: Tue, 08 Nov 2016 08:57:34 GMT
+  recorded_at: Tue, 16 Mar 2021 12:28:19 GMT
 - request:
     method: get
     uri: https://api.chartmogul.com/v1/customers
@@ -200,7 +158,7 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.9.2
+      - Faraday v1.0.1
       Content-Type:
       - application/json
       Authorization:
@@ -208,37 +166,27 @@ http_interactions:
   response:
     status:
       code: 200
-      message:
+      message: OK
     headers:
       server:
       - nginx/1.10.1
       date:
-      - Tue, 08 Nov 2016 08:57:34 GMT
+      - Tue, 16 Mar 2021 12:28:20 GMT
       content-type:
-      - application/json; charset=utf-8
+      - application/json
       transfer-encoding:
       - chunked
       connection:
-      - close
-      x-frame-options:
-      - SAMEORIGIN
-      x-xss-protection:
-      - 1; mode=block
-      x-content-type-options:
-      - nosniff
-      etag:
-      - W/"82f80d77a5a88d6de206bb1feeb897cc"
-      cache-control:
-      - max-age=0, private, must-revalidate
-      x-request-id:
-      - 770d6629-03d8-4f55-8bec-dde047828e7e
-      x-runtime:
-      - '0.019712'
-      strict-transport-security:
-      - max-age=15768000
+      - keep-alive
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      access-control-allow-credentials:
+      - 'true'
     body:
-      encoding: UTF-8
-      string: '{"customers":[],"current_page":1,"total_pages":0,"has_more":false,"per_page":50,"page":1}'
+      encoding: ASCII-8BIT
+      string: '{"entries":[],"current_page":1,"total_pages":1,"has_more":false,"per_page":200,"page":1}'
     http_version:
-  recorded_at: Tue, 08 Nov 2016 08:57:34 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Tue, 16 Mar 2021 12:28:20 GMT
+recorded_with: VCR 5.1.0

--- a/lib/chartmogul/api/actions/all.rb
+++ b/lib/chartmogul/api/actions/all.rb
@@ -16,7 +16,7 @@ module ChartMogul
               end
             end
 
-            json = ChartMogul::Utils::JSONParser.parse(resp.body, skip_case_conversion: skip_case_conversion)
+            json = ChartMogul::Utils::JSONParser.parse(resp.body, immutable_keys: immutable_keys)
             new_from_json(json)
           end
         end

--- a/lib/chartmogul/api/actions/create.rb
+++ b/lib/chartmogul/api/actions/create.rb
@@ -15,7 +15,7 @@ module ChartMogul
               req.body = JSON.dump(serialize_for_write)
             end
           end
-          json = ChartMogul::Utils::JSONParser.parse(resp.body, skip_case_conversion: self.class.skip_case_conversion)
+          json = ChartMogul::Utils::JSONParser.parse(resp.body, immutable_keys: self.class.immutable_keys)
 
           assign_all_attributes(json)
         end
@@ -30,7 +30,7 @@ module ChartMogul
                 req.body = JSON.dump(resource.serialize_for_write)
               end
             end
-            json = ChartMogul::Utils::JSONParser.parse(resp.body, skip_case_conversion: skip_case_conversion)
+            json = ChartMogul::Utils::JSONParser.parse(resp.body, immutable_keys: immutable_keys)
 
             new_from_json(json)
           end

--- a/lib/chartmogul/api/actions/custom.rb
+++ b/lib/chartmogul/api/actions/custom.rb
@@ -25,7 +25,7 @@ module ChartMogul
                 req.body = JSON.dump(body_data)
               end
             end
-            ChartMogul::Utils::JSONParser.parse(resp.body, skip_case_conversion: skip_case_conversion)
+            ChartMogul::Utils::JSONParser.parse(resp.body, immutable_keys: immutable_keys)
           end
 
           def custom!(http_method, http_path, body_data = {})

--- a/lib/chartmogul/api/actions/retrieve.rb
+++ b/lib/chartmogul/api/actions/retrieve.rb
@@ -15,7 +15,8 @@ module ChartMogul
                 req.headers['Content-Type'] = 'application/json'
               end
             end
-            json = ChartMogul::Utils::JSONParser.parse(resp.body, skip_case_conversion: skip_case_conversion)
+
+            json = ChartMogul::Utils::JSONParser.parse(resp.body, immutable_keys: immutable_keys)
             new_from_json(json)
           end
         end

--- a/lib/chartmogul/api/actions/update.rb
+++ b/lib/chartmogul/api/actions/update.rb
@@ -16,7 +16,7 @@ module ChartMogul
             end
           end
 
-          json = ChartMogul::Utils::JSONParser.parse(resp.body, skip_case_conversion: self.class.skip_case_conversion)
+          json = ChartMogul::Utils::JSONParser.parse(resp.body, immutable_keys: self.class.immutable_keys)
 
           assign_all_attributes(json)
         end
@@ -31,7 +31,7 @@ module ChartMogul
                 req.body = JSON.dump(resource.serialize_for_write)
               end
             end
-            json = ChartMogul::Utils::JSONParser.parse(resp.body, skip_case_conversion: skip_case_conversion)
+            json = ChartMogul::Utils::JSONParser.parse(resp.body, immutable_keys: immutable_keys)
 
             new_from_json(json)
           end

--- a/lib/chartmogul/api_resource.rb
+++ b/lib/chartmogul/api_resource.rb
@@ -17,7 +17,7 @@ module ChartMogul
     MAX_INTERVAL = 60
     THREAD_CONNECTION_KEY = 'chartmogul_ruby.api_resource.connection'
 
-    class << self; attr_reader :resource_path, :resource_name, :resource_root_key, :immutable_keys end
+    class << self; attr_reader :resource_path, :resource_name, :resource_root_key end
 
     def self.set_resource_path(path)
       @resource_path = ChartMogul::ResourcePath.new(path)
@@ -31,7 +31,11 @@ module ChartMogul
       @resource_root_key = root_key
     end
 
-    # When true, response hash keys won't be converted to snake case
+    def self.immutable_keys
+      @immutable_keys ||= []
+    end
+
+    # When set with keys, nested hash keys of these immutable keys won't be converted to snake case
     def self.set_immutable_keys(array)
       @immutable_keys = array
     end

--- a/lib/chartmogul/api_resource.rb
+++ b/lib/chartmogul/api_resource.rb
@@ -17,7 +17,7 @@ module ChartMogul
     MAX_INTERVAL = 60
     THREAD_CONNECTION_KEY = 'chartmogul_ruby.api_resource.connection'
 
-    class << self; attr_reader :resource_path, :resource_name, :resource_root_key, :skip_case_conversion end
+    class << self; attr_reader :resource_path, :resource_name, :resource_root_key, :immutable_keys end
 
     def self.set_resource_path(path)
       @resource_path = ChartMogul::ResourcePath.new(path)
@@ -32,8 +32,8 @@ module ChartMogul
     end
 
     # When true, response hash keys won't be converted to snake case
-    def self.set_skip_case_conversion(value)
-      @skip_case_conversion = value
+    def self.set_immutable_keys(array)
+      @immutable_keys = array
     end
 
     def self.connection

--- a/lib/chartmogul/customer.rb
+++ b/lib/chartmogul/customer.rb
@@ -4,7 +4,7 @@ module ChartMogul
   class Customer < APIResource
     set_resource_name 'Customer'
     set_resource_path '/v1/customers'
-    set_skip_case_conversion true
+    set_immutable_keys([:attributes, :custom])
 
     readonly_attr :uuid
     readonly_attr :id
@@ -132,7 +132,7 @@ module ChartMogul
   class Customers < APIResource
     set_resource_name 'Customers'
     set_resource_path '/v1/customers'
-    set_skip_case_conversion true
+    set_immutable_keys([:attributes, :custom])
 
     include Concerns::Entries
     include API::Actions::Custom

--- a/lib/chartmogul/utils/hash_snake_caser.rb
+++ b/lib/chartmogul/utils/hash_snake_caser.rb
@@ -8,8 +8,9 @@ module ChartMogul
       # Rubyish snake_case, suitable for use during instantiation of Ruby
       # model attributes.
       #
-      def initialize(hash)
+      def initialize(hash, immutable_keys)
         @hash = hash
+        @immutable_keys = immutable_keys ||= []
       end
 
       def to_snake_keys(value = @hash)
@@ -26,7 +27,13 @@ module ChartMogul
       private
 
       def snake_hash(value)
-        Hash[value.map { |k, v| [underscore_key(k), to_snake_keys(v)] }]
+        Hash[value.map { |k, v| [underscore_key(k), immutable_check(k, v)] }]
+      end
+
+      def immutable_check(k,v)
+        return v if @immutable_keys.include?(k)
+
+        to_snake_keys(v)
       end
 
       def underscore_key(k)

--- a/lib/chartmogul/utils/hash_snake_caser.rb
+++ b/lib/chartmogul/utils/hash_snake_caser.rb
@@ -8,9 +8,9 @@ module ChartMogul
       # Rubyish snake_case, suitable for use during instantiation of Ruby
       # model attributes.
       #
-      def initialize(hash, immutable_keys)
+      def initialize(hash, immutable_keys: [])
         @hash = hash
-        @immutable_keys = immutable_keys ||= []
+        @immutable_keys = immutable_keys
       end
 
       def to_snake_keys(value = @hash)

--- a/lib/chartmogul/utils/json_parser.rb
+++ b/lib/chartmogul/utils/json_parser.rb
@@ -4,11 +4,9 @@ module ChartMogul
   module Utils
     class JSONParser
       class << self
-        def parse(json_string, skip_case_conversion: false)
+        def parse(json_string, immutable_keys: [])
           hash = JSON.parse(json_string, symbolize_names: true)
-          return hash if skip_case_conversion
-
-          HashSnakeCaser.new(hash).to_snake_keys
+          HashSnakeCaser.new(hash, immutable_keys).to_snake_keys
         end
 
         def typecast_custom_attributes(custom_attributes)

--- a/lib/chartmogul/utils/json_parser.rb
+++ b/lib/chartmogul/utils/json_parser.rb
@@ -6,7 +6,7 @@ module ChartMogul
       class << self
         def parse(json_string, immutable_keys: [])
           hash = JSON.parse(json_string, symbolize_names: true)
-          HashSnakeCaser.new(hash, immutable_keys).to_snake_keys
+          HashSnakeCaser.new(hash, immutable_keys: immutable_keys).to_snake_keys
         end
 
         def typecast_custom_attributes(custom_attributes)

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ChartMogul
-  VERSION = '1.7.1'
+  VERSION = '1.7.2'
 end

--- a/spec/chartmogul/customer_spec.rb
+++ b/spec/chartmogul/customer_spec.rb
@@ -142,7 +142,7 @@ describe ChartMogul::Customer do
       expect(customers.current_page).to eq(1)
       expect(customers.total_pages).to eq(1)
       expect(customers.page).to eq(1)
-      expect(customers.per_page).to eq(50)
+      expect(customers.per_page).to eq(200)
       expect(customers.has_more).to eq(false)
       expect(customers.size).to eq(1)
       expect(customers[0].uuid).not_to be_nil
@@ -154,6 +154,7 @@ describe ChartMogul::Customer do
       expect(customers[0].country).to eq('DE')
       expect(customers[0].lead_created_at).to eq(lead_created_at)
       expect(customers[0].free_trial_started_at).to eq(free_trial_started_at)
+      expect(customers[0].billing_system_type).to eq('Import API')
 
       customer.destroy!
 

--- a/spec/chartmogul/utils/hash_snake_caser_spec.rb
+++ b/spec/chartmogul/utils/hash_snake_caser_spec.rb
@@ -13,7 +13,7 @@ describe ChartMogul::Utils::HashSnakeCaser do
     }
   end
 
-  subject { described_class.new(hash) }
+  subject { described_class.new(hash, []) }
 
   it 'returns snake_cased keys' do
     expect(subject.to_snake_keys).to eq(

--- a/spec/chartmogul/utils/hash_snake_caser_spec.rb
+++ b/spec/chartmogul/utils/hash_snake_caser_spec.rb
@@ -13,7 +13,7 @@ describe ChartMogul::Utils::HashSnakeCaser do
     }
   end
 
-  subject { described_class.new(hash, []) }
+  subject { described_class.new(hash, immutable_keys: []) }
 
   it 'returns snake_cased keys' do
     expect(subject.to_snake_keys).to eq(

--- a/spec/chartmogul/utils/json_parser_spec.rb
+++ b/spec/chartmogul/utils/json_parser_spec.rb
@@ -25,9 +25,9 @@ describe ChartMogul::Utils::JSONParser do
     end
 
     it 'allows skipping camel case conversion' do
-      json = {'aKey': 'a_value', 'bKey': 'b_value'}.to_json
-      result = described_class.parse(json, skip_case_conversion: true)
-      expect(result.keys).to contain_exactly(:aKey,:bKey)
+      json = {'custom': {'aKey': 'a_value', 'bKey': 'b_value'}}.to_json
+      result = described_class.parse(json, immutable_keys: [:custom])
+      expect(result[:custom].keys).to contain_exactly(:aKey,:bKey)
     end
   end
 end


### PR DESCRIPTION
Currently, the Gem converts JSON parsed from response bodies to attributes of the various Ruby objects. Because all the object attributes are snake-cased, we used to snake-case all the JSON keys before using them to set the attributes on the model.

However, that caused issues with custom attributes, because we would snake-case the keys. In order to avoid that, we started skipping this for the customer object.

However, the JSON response for the customer object contains both snake-cased keys (`lead_created_at`) as well as keys with a dash (`billing-system-type`).

This meant that attributes such as `billing-system-type` or `customer-since` weren't being set on the Ruby object.

Therefore, this PR would propose having an array of `immutable_keys` for each Object, which by default is an empty array if not set. Then, for the Customer object we can set it to contain our desired keys for which we will not mutate the nested keys.

I've also re-ran the VCR cassettes for one of the specs, so we get up-to-date responses for the Customer object, including the new attributes and added a spec for it.
