### PR TITLE
Global config [ch30752]

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ This gem supports Ruby 2.3 and above.
 ## Configuration
 
 Configure `chartmogul-ruby` with your Account Token and Secret Key, available from the administration section of your ChartMogul account.
-You can either do this in the global scope for the whole application (eg. in initializer):
+You can either do this in the global scope for the whole runtime (eg. in initializer):
 
 ```ruby
 ChartMogul.global_account_token = '<Account key goes here>'

--- a/README.md
+++ b/README.md
@@ -53,13 +53,20 @@ This gem supports Ruby 2.3 and above.
 ## Configuration
 
 Configure `chartmogul-ruby` with your Account Token and Secret Key, available from the administration section of your ChartMogul account.
+You can either do this in the global scope for the whole application (eg. in initializer):
 
+```ruby
+ChartMogul.global_account_token = '<Account key goes here>'
+ChartMogul.global_secret_key = '<Secret key goes here>'
+```
+
+Or in a thread-safe scope for the current thread only (eg. different accounts in different async jobs):
 ```ruby
 ChartMogul.account_token = '<Account key goes here>'
 ChartMogul.secret_key = '<Secret key goes here>'
 ```
 
-Configuration is threadsafe and applied only to the current thread.
+Thread-safe configuration is used if available, otherwise global is used. 
 
 Test your authentication:
 ```ruby

--- a/lib/chartmogul.rb
+++ b/lib/chartmogul.rb
@@ -79,10 +79,14 @@ module ChartMogul
   class << self
     extend ConfigAttributes
 
+    def global_config
+      @global_config ||= ChartMogul::Configuration.new
+    end
 
+    # This configuration is thread-safe and fits multi-account async
+    # jobs processing use case.
     def config
-      Thread.current[CONFIG_THREAD_KEY] = ChartMogul::Configuration.new if Thread.current[CONFIG_THREAD_KEY].nil?
-      Thread.current[CONFIG_THREAD_KEY]
+      Thread.current[CONFIG_THREAD_KEY] ||= ChartMogul::Configuration.new
     end
 
     config_accessor :account_token

--- a/lib/chartmogul/config_attributes.rb
+++ b/lib/chartmogul/config_attributes.rb
@@ -4,9 +4,18 @@ module ChartMogul
   module ConfigAttributes
     def config_accessor(attribute, default_value = nil)
       define_method(attribute) do
-        attr = config.send(attribute) || default_value
+        attr = config.send(attribute) || global_config.send(attribute) || default_value
         if attr.nil?
           raise ConfigurationError, "Configuration for #{attribute} not set"
+        end
+
+        attr
+      end
+
+      define_method("global_#{attribute}") do
+        attr = global_config.send(attribute) || default_value
+        if attr.nil?
+          raise ConfigurationError, "Global configuration for #{attribute} not set"
         end
 
         attr
@@ -15,6 +24,13 @@ module ChartMogul
       define_method("#{attribute}=") do |val|
         config.send("#{attribute}=", val)
         Thread.current[ChartMogul::APIResource::THREAD_CONNECTION_KEY] = nil
+        val
+      end
+
+      define_method("global_#{attribute}=") do |val|
+        global_config.send("#{attribute}=", val)
+        Thread.current[ChartMogul::APIResource::THREAD_CONNECTION_KEY] = nil
+        val
       end
     end
   end

--- a/spec/chartmogul/configuration_spec.rb
+++ b/spec/chartmogul/configuration_spec.rb
@@ -4,6 +4,8 @@ require 'spec_helper'
 
 describe 'ChartMogul configuration' do
   describe 'account_token' do
+    after { ChartMogul.global_account_token = nil }
+
     it 'sets the configuration' do
       ChartMogul.account_token = 'abcdef1234567890'
       expect(ChartMogul.account_token).to eq('abcdef1234567890')
@@ -12,6 +14,13 @@ describe 'ChartMogul configuration' do
     it 'raises a ChartMogul::ConfigurationError when not set' do
       ChartMogul.account_token = nil
       expect { ChartMogul.account_token }.to raise_error(ChartMogul::ConfigurationError)
+    end
+
+    it 'uses global configuration' do
+      ChartMogul.global_account_token = 'global_account_token'
+      ChartMogul.account_token = nil
+
+      expect(ChartMogul.account_token).to eq('global_account_token')
     end
   end
 
@@ -43,6 +52,9 @@ describe 'ChartMogul configuration' do
   end
 
   describe 'global_account_token' do
+
+    after { ChartMogul.global_account_token = nil }
+
     it 'sets the global configuration' do
       ChartMogul.global_account_token = 'abcdef1234567890'
       expect(ChartMogul.account_token).to eq('abcdef1234567890')

--- a/spec/chartmogul/configuration_spec.rb
+++ b/spec/chartmogul/configuration_spec.rb
@@ -41,4 +41,19 @@ describe 'ChartMogul configuration' do
       expect(ChartMogul.api_base).to eq ChartMogul::API_BASE
     end
   end
+
+  describe 'global_account_token' do
+    it 'sets the global configuration' do
+      ChartMogul.global_account_token = 'abcdef1234567890'
+      expect(ChartMogul.account_token).to eq('abcdef1234567890')
+      expect(ChartMogul.global_account_token).to eq('abcdef1234567890')
+    end
+
+    it 'thread-safe overrides global configuration' do
+      ChartMogul.global_account_token = 'abcdef1234567890'
+      expect(ChartMogul.account_token).to eq('abcdef1234567890')
+      ChartMogul.account_token = '00000000000'
+      expect(ChartMogul.account_token).to eq('00000000000')
+    end
+  end
 end


### PR DESCRIPTION
This should solve issues like #105, where users don't actually want thread-safety, but easy global configuration.
This change is backwards compatible in the sense that it keeps current behavior and reintroduces the old one under a prefix.
Hopefully this will make the library easier to set up in the common use case of just one-account integration.