### PR TITLE
Relax faraday dependency for Ruby 3

### DIFF
--- a/chartmogul-ruby.gemspec
+++ b/chartmogul-ruby.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables           = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths         = ['lib']
 
-  spec.add_dependency 'faraday', '~> 1.0.0'
+  spec.add_dependency 'faraday', '~> 1.0'
 
   spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'pry', '~> 0.12.2'


### PR DESCRIPTION
Hello!! We are using ChartMogul and trying to get to Ruby 3.

[Faraday v1.3.0 supports Ruby 3](https://github.com/lostisland/faraday/blob/main/CHANGELOG.md#v130-2020-12-31) so we need ChartMogul needs to relax the dependency of faraday.

Thanks!!