### PR TITLE
Add async activities export [ch32201]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,11 @@
 # chartmogul-ruby Change Log
 
+## Version 2.1.0 - 9 July 2021
+- Adds ChartMogul::Metrics::ActivitiesExport class to support async activities export endpoint
+
 ## Version 2.0.0 - 25 June 2021
 - Moves customer scoped Metrics::Activities and Metrics::Subscriptions under Metrics::Customers namespace
-- Adds unscoped activites API endpoint
+- Adds unscoped activities API endpoint
 
 ## Version 1.7.2 - 16 March 2021
 - Fix bug preventing instantiating attributes on ChartMogul::Customers objects

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_ActivitiesExport/get_activities_export.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_ActivitiesExport/get_activities_export.yml
@@ -1,0 +1,43 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/activities_export/44037b8f-4a89-4fc6-8114-2288c71a9518
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic hidden
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Fri, 09 Jul 2021 14:06:07 GMT
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"44037b8f-4a89-4fc6-8114-2288c71a9518","status":"succeeded","file_url":"https://chartmogul-customer-export.s3.eu-west-1.amazonaws.com/activities-acme-corp-062ea48c-5d74-46dd-bd60-23206cdc241a.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=123%2Feu-west-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210709T135547Z\u0026X-Amz-Expires=604800\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=abc","params":{"kind":"activities","params":{"end_date":"2020-12-31
+        00:00:00 +0000","start_date":"2020-01-01 00:00:00 +0000","activity_type":"new_biz"}},"expires_at":"2021-07-16T13:55:47+00:00","created_at":"2021-07-09T13:55:44+00:00"}'
+    http_version:
+  recorded_at: Fri, 09 Jul 2021 14:06:07 GMT
+recorded_with: VCR 5.1.0

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_ActivitiesExport/post_activities_export.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_ActivitiesExport/post_activities_export.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.chartmogul.com/v1/activities_export
     body:
       encoding: UTF-8
-      string: '{"start_date":"2020-01-01 00:00:00 +0000","end_date":"2020-12-31 00:00:00
+      string: '{"start-date":"2020-01-01 00:00:00 +0000","end-date":"2020-12-31 00:00:00
         +0000","type":"new_biz"}'
     headers:
       User-Agent:

--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_ActivitiesExport/post_activities_export.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_ActivitiesExport/post_activities_export.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/activities_export
+    body:
+      encoding: UTF-8
+      string: '{"start_date":"2020-01-01 00:00:00 +0000","end_date":"2020-12-31 00:00:00
+        +0000","type":"new_biz"}'
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic hidden
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Fri, 09 Jul 2021 14:37:32 GMT
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"17042239-3674-4a61-b838-b6b307f28506","status":"pending","file_url":null,"params":{"kind":"activities","params":{"activity_type":"new_biz","start_date":"2020-01-01
+        00:00:00 +0000","end_date":"2020-12-31 00:00:00 +0000"}},"expires_at":null,"created_at":"2021-07-09T14:37:32+00:00"}'
+    http_version:
+  recorded_at: Fri, 09 Jul 2021 14:37:32 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/activities_export/17042239-3674-4a61-b838-b6b307f28506
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic hidden
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      server:
+      - nginx/1.10.1
+      date:
+      - Fri, 09 Jul 2021 14:38:10 GMT
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      vary:
+      - Accept-Encoding, Accept-Encoding
+      status:
+      - 200 OK
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"17042239-3674-4a61-b838-b6b307f28506","status":"succeeded","file_url":"https://chartmogul-customer-export.s3.eu-west-1.amazonaws.com/activities-acme-corp-062ea48c-5d74-46dd-bd60-23206cdc241a.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=123%2Feu-west-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20210709T135547Z\u0026X-Amz-Expires=604800\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Signature=abc","params":{"kind":"activities","params":{"end_date":"2020-12-31
+        00:00:00 +0000","start_date":"2020-01-01 00:00:00 +0000","activity_type":"new_biz"}},"expires_at":"2021-07-16T14:37:43+00:00","created_at":"2021-07-09T14:37:32+00:00"}'
+    http_version:
+  recorded_at: Fri, 09 Jul 2021 14:38:10 GMT
+recorded_with: VCR 5.1.0

--- a/lib/chartmogul.rb
+++ b/lib/chartmogul.rb
@@ -70,6 +70,7 @@ require 'chartmogul/metrics/base'
 require 'chartmogul/metrics/customers/activity'
 require 'chartmogul/metrics/customers/subscription'
 require 'chartmogul/metrics/activity'
+require 'chartmogul/metrics/activities_export'
 
 require 'chartmogul/enrichment/customer'
 

--- a/lib/chartmogul/metrics/activities_export.rb
+++ b/lib/chartmogul/metrics/activities_export.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module ChartMogul
+  module Metrics
+    class ActivitiesExport < APIResource
+      set_resource_name 'ActivitiesExport'
+      set_resource_path '/v1/activities_export'
+
+      readonly_attr :id
+      readonly_attr :status
+      readonly_attr :file_url
+      readonly_attr :params
+      readonly_attr :expires_at
+      readonly_attr :created_at
+
+      writeable_attr :start_date
+      writeable_attr :end_date
+      writeable_attr :type
+
+      include API::Actions::Retrieve
+      include API::Actions::Create
+
+      def reload
+        self.class.retrieve(id)
+      end
+    end
+  end
+end

--- a/lib/chartmogul/metrics/activities_export.rb
+++ b/lib/chartmogul/metrics/activities_export.rb
@@ -19,10 +19,6 @@ module ChartMogul
 
       include API::Actions::Retrieve
       include API::Actions::Create
-
-      def reload
-        self.class.retrieve(id)
-      end
     end
   end
 end

--- a/lib/chartmogul/metrics/activities_export.rb
+++ b/lib/chartmogul/metrics/activities_export.rb
@@ -19,6 +19,20 @@ module ChartMogul
 
       include API::Actions::Retrieve
       include API::Actions::Create
+
+      def serialize_for_write
+        super.tap do |attributes|
+          attributes.clone.each do |k, v|
+            attributes[preprocess_attributes(k)] = attributes.delete(k)
+          end
+        end
+      end
+
+      def preprocess_attributes(attribute)
+        return attribute unless %i[start_date end_date].include?(attribute)
+
+        attribute.to_s.tr('_', '-')
+      end
     end
   end
 end

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ChartMogul
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end

--- a/spec/chartmogul/metrics/activities_export_spec.rb
+++ b/spec/chartmogul/metrics/activities_export_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ChartMogul::Metrics::ActivitiesExport do
+  describe 'API interactions', vcr: true, uses_api: true do
+    describe '#create!' do
+      it 'returns a pending activity export', vcr: 'ChartMogul_Metrics_ActivitiesExport/post_activities_export' do
+        activities_export = ChartMogul::Metrics::ActivitiesExport.create!(
+          start_date: Time.parse('2020-01-01').to_s,
+          end_date: Time.parse('2020-12-31').to_s,
+          type: 'new_biz'
+        )
+
+        expect(activities_export.status).to eq('pending')
+        expect(activities_export.file_url).to be_nil
+
+        # the async export must be reloaded periodically until it is sucessful or fails permanently
+        activities_export = activities_export.reload
+
+        expect(activities_export.status).to eq('succeeded')
+        expect(activities_export.file_url).not_to be_nil
+      end
+    end
+
+    describe '#retrieve', vcr: 'ChartMogul_Metrics_ActivitiesExport/get_activities_export' do
+      it 'returns the finished activity export' do
+        activities_export = ChartMogul::Metrics::ActivitiesExport.retrieve('44037b8f-4a89-4fc6-8114-2288c71a9518')
+        expect(activities_export.status).to eq('succeeded')
+        expect(activities_export.file_url).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/chartmogul/metrics/activities_export_spec.rb
+++ b/spec/chartmogul/metrics/activities_export_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ChartMogul::Metrics::ActivitiesExport do
         expect(activities_export.file_url).to be_nil
 
         # the async export must be reloaded periodically until it is sucessful or fails permanently
-        activities_export = activities_export.reload
+        activities_export = ChartMogul::Metrics::ActivitiesExport.retrieve(activities_export.id)
 
         expect(activities_export.status).to eq('succeeded')
         expect(activities_export.file_url).not_to be_nil

--- a/spec/chartmogul/metrics/activities_export_spec.rb
+++ b/spec/chartmogul/metrics/activities_export_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe ChartMogul::Metrics::ActivitiesExport do
   describe 'API interactions', vcr: true, uses_api: true do
     describe '#create!' do
-      it 'returns a pending activity export', vcr: 'ChartMogul_Metrics_ActivitiesExport/post_activities_export' do
+      it 'returns a pending activity export', vcr: { cassette_name: 'ChartMogul_Metrics_ActivitiesExport/post_activities_export', match_requests_on: [:method, :uri, :body] } do
         activities_export = ChartMogul::Metrics::ActivitiesExport.create!(
           start_date: Time.parse('2020-01-01').to_s,
           end_date: Time.parse('2020-12-31').to_s,


### PR DESCRIPTION
This PR provides support for a new async activities export:

```
activities_export = ChartMogul::Metrics::ActivitiesExport.create!(
          start_date: Time.parse('2020-01-01').to_s,
          end_date: Time.parse('2020-12-31').to_s,
          type: 'new_biz'
        )
```


Initially, the export will have the status `pending` and a `nil` file_url. After a period of time, the async job will complete and the status will update to `processing` and then `succeeded` or `failed`. In the case of `succeeded`, the `file_url` will be populated with the url with the zipped activities export.

In the success case, you'd get something like:

```
 #<ChartMogul::Metrics::ActivitiesExport:0x00007fcb4a9ee950
 @created_at="2021-07-09T14:37:32+00:00",
 @expires_at="2021-07-16T14:37:43+00:00",
 @file_url=
  "https://chartmogul-customer-export.s3.eu-west-1.amazonaws.com/activities-acme-corp-062ea48c-5d74-46dd-bd60-23206cdc241a.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=123%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20210709T135547Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=abc",
 @id="17042239-3674-4a61-b838-b6b307f28506",
 @params={:kind=>"activities", :params=>{:end_date=>"2020-12-31 00:00:00 +0000", :start_date=>"2020-01-01 00:00:00 +0000", :activity_type=>"new_biz"}},
 @status="succeeded">
```

If you have the uuid of the export, you can retrieve it via:

```
activities_export = ChartMogul::Metrics::ActivitiesExport.retrieve('44037b8f-4a89-4fc6-8114-2288c71a9518')
```

In addition, the version is bumped to 2.1.0