### PR TITLE
Pass dev env failing spec by fixing timezone of timestamp [ch32201]

### DIFF
--- a/fixtures/vcr_cassettes/ChartMogul_Metrics_ActivitiesExport/post_activities_export.yml
+++ b/fixtures/vcr_cassettes/ChartMogul_Metrics_ActivitiesExport/post_activities_export.yml
@@ -5,8 +5,7 @@ http_interactions:
     uri: https://api.chartmogul.com/v1/activities_export
     body:
       encoding: UTF-8
-      string: '{"start-date":"2020-01-01 00:00:00 +0000","end-date":"2020-12-31 00:00:00
-        +0000","type":"new_biz"}'
+      string: '{"start-date":"2020-01-01T00:00:00Z","end-date":"2020-12-31T00:00:00Z","type":"new_biz"}'
     headers:
       User-Agent:
       - Faraday v1.0.1

--- a/spec/chartmogul/metrics/activities_export_spec.rb
+++ b/spec/chartmogul/metrics/activities_export_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe ChartMogul::Metrics::ActivitiesExport do
     describe '#create!' do
       it 'returns a pending activity export', vcr: { cassette_name: 'ChartMogul_Metrics_ActivitiesExport/post_activities_export', match_requests_on: [:method, :uri, :body] } do
         activities_export = ChartMogul::Metrics::ActivitiesExport.create!(
-          start_date: Time.parse('2020-01-01').to_s,
-          end_date: Time.parse('2020-12-31').to_s,
+          start_date: '2020-01-01T00:00:00Z',
+          end_date: '2020-12-31T00:00:00Z',
           type: 'new_biz'
         )
 


### PR DESCRIPTION
The spec in spec/chartmogul/metrics/activities_export_spec.rb:8 was failing in local development environment because of time zone mismatch between the local environment and timestamp set in vcr cassette. 