### PR TITLE
Add user agent with lib version [ch35959]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Version 3.0.0 - 29 October 2021
 - Update ChartMogul::Configuration to use `api_key` instead of `account_token`& `secret_key` combo for authentication
+- Send library version as part of `User-Agent` header
 
 ## Version 2.9.0 - 3 Nov 2021
 - Adds post install message informing about authentication changes *& deprecation warning.

--- a/lib/chartmogul/api_resource.rb
+++ b/lib/chartmogul/api_resource.rb
@@ -89,7 +89,7 @@ module ChartMogul
     private
 
     def self.build_connection
-      Faraday.new(url: ChartMogul.api_base) do |faraday|
+      Faraday.new(url: ChartMogul.api_base, headers: { 'User-Agent' => "chartmogul-ruby/#{ChartMogul::VERSION}" }) do |faraday|
         faraday.use Faraday::Request::BasicAuthentication, ChartMogul.api_key, ''
         faraday.use Faraday::Response::RaiseError
         faraday.request :retry, max: ChartMogul.max_retries, retry_statuses: RETRY_STATUSES,

--- a/spec/chartmogul/api_resource_spec.rb
+++ b/spec/chartmogul/api_resource_spec.rb
@@ -5,6 +5,11 @@ require 'pry'
 
 describe ChartMogul::APIResource do
   describe 'connection', vcr: true do
+    it 'adds User-Agent header' do
+      set_valid_credentials
+      expect(ChartMogul::APIResource.connection.headers["User-Agent"]).to eq("chartmogul-ruby/#{ChartMogul::VERSION}")
+    end
+
     it 'works when credentials are updated' do
       set_invalid_credentials
       expect { ChartMogul::Ping.ping }.to raise_error(ChartMogul::UnauthorizedError)


### PR DESCRIPTION
Shortcut ticket: https://app.shortcut.com/chartmogul/story/35959/include-client-version-header-in-library-ruby

This adds header to every single request that will look something like this:

```
'User-Agent': 'chartmogul-ruby/3.0.0'
```