### PR TITLE
[sc-50895] Upgrade Faraday

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0]
+        ruby-version: [2.6, 2.7, 3.0, 3.1, 3.2]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # chartmogul-ruby Change Log
 
+## Version 3.2.0 - June 14 2023
+- Adds support for Faraday 2.7
+- Removes support for Ruby 2.3, 2.4, and 2.5
+
 ## Version 3.1.0 - Mar 30 2023
 - Adds support for Contacts (https://dev.chartmogul.com/reference/contacts)
 

--- a/chartmogul-ruby.gemspec
+++ b/chartmogul-ruby.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables           = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths         = ['lib']
 
-  spec.add_dependency 'faraday', '~> 1.0'
+  spec.add_dependency 'faraday', '~> 2.7'
 
   spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'pry', '~> 0.12.2'

--- a/chartmogul-ruby.gemspec
+++ b/chartmogul-ruby.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths         = ['lib']
 
   spec.add_dependency 'faraday', '~> 2.7'
+  spec.add_dependency 'faraday-retry', '~> 2.2'
 
   spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'pry', '~> 0.12.2'

--- a/lib/chartmogul.rb
+++ b/lib/chartmogul.rb
@@ -3,6 +3,7 @@
 require 'time'
 require 'json'
 require 'faraday'
+require 'faraday/retry'
 
 require 'chartmogul/version'
 

--- a/lib/chartmogul/api_resource.rb
+++ b/lib/chartmogul/api_resource.rb
@@ -90,8 +90,8 @@ module ChartMogul
 
     def self.build_connection
       Faraday.new(url: ChartMogul.api_base, headers: { 'User-Agent' => "chartmogul-ruby/#{ChartMogul::VERSION}" }) do |faraday|
-        faraday.use Faraday::Request::BasicAuthentication, ChartMogul.api_key, ''
         faraday.use Faraday::Response::RaiseError
+        faraday.request :authorization, :basic, ChartMogul.api_key, ''
         faraday.request :retry, max: ChartMogul.max_retries, retry_statuses: RETRY_STATUSES,
                                 max_interval: MAX_INTERVAL, backoff_factor: BACKOFF_FACTOR,
                                 interval_randomness: INTERVAL_RANDOMNESS, interval: INTERVAL, exceptions: RETRY_EXCEPTIONS

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ChartMogul
-  VERSION = '3.1.0'
+  VERSION = '3.2.0'
 end


### PR DESCRIPTION
This change adds support for Faraday 2.7 - see related issue here: https://github.com/chartmogul/chartmogul-ruby/issues/134