### PR TITLE
Add invoice external id to Subscription Event CSV [SC-55167]

### DIFF
--- a/lib/chartmogul/csv/subscription_event.rb
+++ b/lib/chartmogul/csv/subscription_event.rb
@@ -3,7 +3,7 @@
 module ChartMogul
   module CSV
     class SubscriptionEvent < Base
-      SUBSCRIPTION_EVENT_HEADERS = %w[External\ ID Subscription\ set\ external\ ID Subscription\ external\ ID Customer\ external\ ID Plan\ external\ ID Date Effective\ Date Event\ Type Currency Amount\ in\ Cents Quantity Retracted\ event\ ID Event\ Order].freeze
+      SUBSCRIPTION_EVENT_HEADERS = %w[External\ ID Subscription\ set\ external\ ID Subscription\ external\ ID Customer\ external\ ID Plan\ external\ ID Date Effective\ Date Event\ Type Currency Amount\ in\ Cents Quantity Retracted\ event\ ID Event\ Order Invoice\ external\ ID].freeze
 
       # https://github.com/chartmogul/platform/blob/main/engines/data_ingestion/app/services/data_ingestion/csv_mapping/subscription_event.rb
       writeable_attr :external_id
@@ -19,6 +19,7 @@ module ChartMogul
       writeable_attr :quantity
       writeable_attr :retracted_event_id
       writeable_attr :event_order
+      writeable_attr :invoice_external_id
 
       def self.headers
         SUBSCRIPTION_EVENT_HEADERS

--- a/spec/chartmogul/csv/subscription_event_spec.rb
+++ b/spec/chartmogul/csv/subscription_event_spec.rb
@@ -9,6 +9,8 @@ describe ChartMogul::CSV::SubscriptionEvent do
         external_id: 'external_id',
         subscription_set_external_id: 'subscription_set_external_id',
         effective_date: Time.new(2020, 8, 24, 8, 22, 15),
+        event_order: 1000,
+        invoice_external_id: 12345
       )
     end
 
@@ -24,9 +26,17 @@ describe ChartMogul::CSV::SubscriptionEvent do
       expect(csv_subscription_event.effective_date).to eq(Time.new(2020, 8, 24, 8, 22, 15))
     end
 
+    it 'sets event_order correctly' do
+      expect(csv_subscription_event.event_order).to eq(1000)
+    end
+
+    it 'sets invoice_external_id correctly' do
+      expect(csv_subscription_event.invoice_external_id).to eq(12345)
+    end
+
     it 'returns the correct headers' do
       expect(described_class.headers)
-        .to eq(%w[External\ ID Subscription\ set\ external\ ID Subscription\ external\ ID Customer\ external\ ID Plan\ external\ ID Date Effective\ Date Event\ Type Currency Amount\ in\ Cents Quantity Retracted\ event\ ID Event\ Order].freeze)
+        .to eq(%w[External\ ID Subscription\ set\ external\ ID Subscription\ external\ ID Customer\ external\ ID Plan\ external\ ID Date Effective\ Date Event\ Type Currency Amount\ in\ Cents Quantity Retracted\ event\ ID Event\ Order Invoice\ external\ ID].freeze)
     end
   end
 end


### PR DESCRIPTION
In the scope of Deprecation of Cancellation table, integrations will start to send subscription events instead of cancellations. To be able to fill the invoice_external_id, field is added to the subscription event CSV. 