### PR TITLE
Support uuid attribute for subscription resource

### DIFF
--- a/lib/chartmogul/metrics/customers/subscription.rb
+++ b/lib/chartmogul/metrics/customers/subscription.rb
@@ -5,6 +5,7 @@ module ChartMogul
     module Customers
       class Subscription < ChartMogul::Object
         readonly_attr :id
+        readonly_attr :uuid
         readonly_attr :external_id
         readonly_attr :plan
         readonly_attr :quantity

--- a/spec/chartmogul/metrics/customers/subscriptions_spec.rb
+++ b/spec/chartmogul/metrics/customers/subscriptions_spec.rb
@@ -18,6 +18,7 @@ describe ChartMogul::Metrics::Customers::Subscription, vcr: true, uses_api: true
     subscription = response[0]
     expect(subscription).to be_kind_of(ChartMogul::Metrics::Customers::Subscription)
     expect(subscription.id).not_to be_nil
+    expect(subscription.uuid).not_to be_nil
     expect(subscription.plan).not_to be_nil
     expect(subscription.quantity).not_to be_nil
     expect(subscription.mrr).not_to be_nil


### PR DESCRIPTION
Add `:uuid` field for metrics/customer/subscription resource. Tested manually using bin/console.
![image](https://github.com/chartmogul/chartmogul-ruby/assets/15037/9f718806-84a7-433a-82bc-f224f6af6d58)
