### PR TITLE
[sc-62677] SDK Unmerge Support - Ruby - remove unmerge-all constant

### DIFF
--- a/lib/chartmogul/customer.rb
+++ b/lib/chartmogul/customer.rb
@@ -45,8 +45,6 @@ module ChartMogul
     include API::Actions::Retrieve
     include API::Actions::Update
 
-    UNMERGE_MOVE_ALL = %w[tasks opportunities notes].freeze
-
     def self.all(options = {})
       Customers.all(options)
     end


### PR DESCRIPTION
Story details: https://app.shortcut.com/chartmogul/story/62677

This PR removes an unnecessary constant that was added in the previous PR. We've decided to handle the "move all objects to new customer" scenario by adding an "all" option to the API instead of providing constants in the SDKs.