### PR TITLE
Add Tasks API support to Ruby Client [sc-66752]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # chartmogul-ruby Change Log
 
+## Version 4.7.0 - April 25, 2025
+- Adds support for Tasks (https://dev.chartmogul.com/reference/tasks)
+
 ## Version 4.6.0 - March 14, 2025
 - Adds support for disconnecting subscriptions
 - Adds support for `transaction_fees_in_cents` attribute on transactions

--- a/lib/chartmogul.rb
+++ b/lib/chartmogul.rb
@@ -65,6 +65,7 @@ require 'chartmogul/plan_groups/plans'
 require 'chartmogul/account'
 require 'chartmogul/subscription_event'
 require 'chartmogul/opportunity'
+require 'chartmogul/task'
 
 require 'chartmogul/metrics/arpa'
 require 'chartmogul/metrics/arr'

--- a/lib/chartmogul/customer.rb
+++ b/lib/chartmogul/customer.rb
@@ -113,6 +113,14 @@ module ChartMogul
       Opportunity.create!(options.merge(customer_uuid: uuid))
     end
 
+    def tasks(options = {})
+      Tasks.all(options.merge(customer_uuid: uuid))
+    end
+
+    def create_task(options = {})
+      Task.create!(options.merge(customer_uuid: uuid))
+    end
+
     # Enrichment
     def tags
       @attributes[:tags]

--- a/lib/chartmogul/task.rb
+++ b/lib/chartmogul/task.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+module ChartMogul
+  class Task < APIResource
+    set_resource_name 'Task'
+    set_resource_path '/v1/tasks'
+
+    readonly_attr :task_uuid
+    readonly_attr :created_at
+    readonly_attr :updated_at
+
+    writeable_attr :customer_uuid
+    writeable_attr :task_details
+    writeable_attr :assignee
+    writeable_attr :due_date
+    writeable_attr :completed_at
+
+    include API::Actions::Create
+    include API::Actions::Destroy
+    include API::Actions::Retrieve
+    include API::Actions::Update
+
+    def self.all(options = {})
+      Tasks.all(options)
+    end
+  end
+
+  class Tasks < APIResource
+    set_resource_name 'Tasks'
+    set_resource_path '/v1/tasks'
+
+    include Concerns::Entries
+    include Concerns::PageableWithCursor
+
+    set_entry_class Task
+  end
+end

--- a/lib/chartmogul/task.rb
+++ b/lib/chartmogul/task.rb
@@ -7,11 +7,11 @@ module ChartMogul
     set_resource_name 'Task'
     set_resource_path '/v1/tasks'
 
+    readonly_attr :customer_uuid
     readonly_attr :task_uuid
     readonly_attr :created_at
     readonly_attr :updated_at
 
-    writeable_attr :customer_uuid
     writeable_attr :task_details
     writeable_attr :assignee
     writeable_attr :due_date

--- a/lib/chartmogul/version.rb
+++ b/lib/chartmogul/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ChartMogul
-  VERSION = '4.6.0'
+  VERSION = '4.7.0'
 end

--- a/spec/chartmogul/customer_spec.rb
+++ b/spec/chartmogul/customer_spec.rb
@@ -107,7 +107,7 @@ describe ChartMogul::Customer do
 
   describe 'API Actions', uses_api: true, vcr: true do
     let(:lead_created_at) { Time.utc(2015, 11, 1) }
-    let(:free_trial_started_at) { Time.utc(2015, 11, 17, 0o1, 20) }
+    let(:free_trial_started_at) { Time.utc(2015, 11, 17, 1, 20) }
 
     it 'retrieves the customer correctly' do
       customer = described_class.retrieve(customer_uuid)

--- a/spec/chartmogul/task_spec.rb
+++ b/spec/chartmogul/task_spec.rb
@@ -23,11 +23,13 @@ describe ChartMogul::Task do
     subject { described_class.new(attrs) }
 
     it 'sets the read-only properties correctly' do
-      expect(subject).to have_attributes({ task_uuid: nil, created_at: nil, updated_at: nil })
+      expect(subject).to have_attributes({ customer_uuid: nil, task_uuid: nil, created_at: nil, updated_at: nil })
     end
 
     it 'sets the writeable properties correctly' do
-      expect(subject).to have_attributes(attrs.reject { |k, _| %i[task_uuid created_at updated_at].include?(k) })
+      expect(subject).to have_attributes(attrs.reject do |k, _|
+                                           %i[customer_uuid task_uuid created_at updated_at].include?(k)
+                                         end)
     end
   end
 

--- a/spec/chartmogul/task_spec.rb
+++ b/spec/chartmogul/task_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ChartMogul::Task do
+  let(:attrs) do
+    {
+      task_uuid: task_uuid,
+      customer_uuid: customer_uuid,
+      task_details: 'This is some task details text.',
+      assignee: 'keith+test1@chartmogul.com',
+      due_date: '2025-04-30T00:00:00.000Z',
+      completed_at: nil
+    }
+  end
+
+  let(:task_uuid) { '6c969fee-2179-11f0-8d8c-ef2a5afba642' }
+  let(:customer_uuid) { 'cus_9c8cc2bd-762e-4d93-ae34-1cfb53a53f64' }
+  let(:updated_attributes) { { task_details: 'This is updated task details text.' } }
+  let(:cursor) { 'MjAyNS0wNC0yNVQwMjowMTowOC4zNTM0NDEwMDBaJjI3NWJjMGJjLTIxNzktMTFmMC04OTdiLWYzZTcwZDJhYTU4ZA==' }
+
+  describe '#initialize' do
+    subject { described_class.new(attrs) }
+
+    it 'sets the read-only properties correctly' do
+      expect(subject).to have_attributes({ task_uuid: nil, created_at: nil, updated_at: nil })
+    end
+
+    it 'sets the writeable properties correctly' do
+      expect(subject).to have_attributes(attrs.reject { |k, _| %i[task_uuid created_at updated_at].include?(k) })
+    end
+  end
+
+  describe '.new_from_json' do
+    subject { described_class.new_from_json(attrs) }
+
+    it 'sets all properties correctly' do
+      expect(subject).to have_attributes(attrs)
+    end
+  end
+
+  describe 'API Actions', uses_api: true, vcr: true do
+    it 'retrieves all tasks correctly' do
+      tasks = described_class.all(customer_uuid: customer_uuid)
+
+      expect(tasks.first).to have_attributes(
+        task_uuid: task_uuid,
+        customer_uuid: customer_uuid
+      )
+      expect(tasks.cursor).to eq(cursor)
+      expect(tasks.has_more).to eq(false)
+    end
+
+    it 'retrieves a task correctly' do
+      task = described_class.retrieve(task_uuid)
+
+      expect(task).to have_attributes(
+        task_uuid: task_uuid,
+        customer_uuid: customer_uuid
+      )
+    end
+
+    it 'creates a task correctly' do
+      attributes = attrs.reject { |key, _| key == :task_uuid }
+      task = described_class.create!(**attributes)
+      expect(task).to have_attributes(**attributes)
+    end
+
+    it 'updates the task correctly with the class method' do
+      updated_task = described_class.update!(
+        task_uuid, **updated_attributes
+      )
+
+      expect(updated_task).to have_attributes(
+        task_uuid: task_uuid,
+        customer_uuid: customer_uuid,
+        **updated_attributes
+      )
+    end
+
+    it 'destroys the task correctly' do
+      target_task_uuid = 'd8c374e0-b9ef-47cf-a5a5-4c71fe0a1466'
+      deleted_task = described_class.destroy!(uuid: target_task_uuid)
+      expect(deleted_task).to eq(true)
+    end
+
+    context 'with old pagination' do
+      let(:get_resources) { described_class.all(per_page: 1, page: 3) }
+
+      it_behaves_like 'raises deprecated param error'
+    end
+
+    context 'with pagination' do
+      let(:first_cursor) do
+        'MjAyNS0wNC0yNVQwMjoxNTowNi40NzQzNTQwMDBaJjFhZWFlMTA4LTIxN2ItMTFmMC1iMmI0LTViNDJmMDI1MDYyYw=='
+      end
+      let(:next_cursor) do
+        'MjAyNS0wNC0yNVQwMjoxMjo1MS43NTc5NTcwMDBaJmNhOWVjOWM2LTIxN2EtMTFmMC1iMWUyLTZmNjczZGFjYmI4Nw=='
+      end
+
+      it 'paginates correctly' do
+        tasks = ChartMogul::Task.all(per_page: 1)
+        expect(tasks).to have_attributes(
+          cursor: first_cursor,
+          has_more: true,
+          size: 1
+        )
+        expect(tasks.first).to have_attributes(task_uuid: '1aeae108-217b-11f0-b2b4-5b42f025062c')
+
+        next_tasks = tasks.next(per_page: 1, customer_uuid: customer_uuid)
+        expect(next_tasks).to have_attributes(
+          cursor: next_cursor,
+          has_more: false,
+          size: 1
+        )
+        expect(next_tasks.first).to have_attributes(task_uuid: task_uuid)
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/ChartMogul_Customer/API_Actions/creates_a_task_belonging_to_the_customer_correctly.yml
+++ b/spec/fixtures/vcr_cassettes/ChartMogul_Customer/API_Actions/creates_a_task_belonging_to_the_customer_correctly.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/tasks
+    body:
+      encoding: UTF-8
+      string: '{"customer_uuid":"cus_9c8cc2bd-762e-4d93-ae34-1cfb53a53f64","task_details":"This
+        is some task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00Z"}'
+    headers:
+      User-Agent:
+      - chartmogul-ruby/4.6.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic hidden
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      date:
+      - Fri, 25 Apr 2025 02:03:03 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '338'
+      connection:
+      - keep-alive
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"task_uuid":"6bedc144-2179-11f0-9074-47237186e386","customer_uuid":"cus_9c8cc2bd-762e-4d93-ae34-1cfb53a53f64","task_details":"This
+        is some task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00.000Z","completed_at":null,"created_at":"2025-04-25T02:03:03.396Z","updated_at":"2025-04-25T02:03:03.396Z"}'
+  recorded_at: Fri, 25 Apr 2025 02:03:03 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/ChartMogul_Customer/API_Actions/lists_the_tasks_belonging_to_the_customer_correctly.yml
+++ b/spec/fixtures/vcr_cassettes/ChartMogul_Customer/API_Actions/lists_the_tasks_belonging_to_the_customer_correctly.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/tasks?customer_uuid=cus_9c8cc2bd-762e-4d93-ae34-1cfb53a53f64
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - chartmogul-ruby/4.6.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic hidden
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Fri, 25 Apr 2025 02:03:02 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '473'
+      connection:
+      - keep-alive
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"entries":[{"task_uuid":"275bc0bc-2179-11f0-897b-f3e70d2aa58d","customer_uuid":"cus_9c8cc2bd-762e-4d93-ae34-1cfb53a53f64","task_details":"This
+        is some task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00.000Z","completed_at":null,"created_at":"2025-04-25T02:01:08.353Z","updated_at":"2025-04-25T02:01:08.353Z"}],"cursor":"MjAyNS0wNC0yNVQwMjowMTowOC4zNTM0NDEwMDBaJjI3NWJjMGJjLTIxNzktMTFmMC04OTdiLWYzZTcwZDJhYTU4ZA==","has_more":false}'
+  recorded_at: Fri, 25 Apr 2025 02:03:02 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/ChartMogul_Task/API_Actions/creates_a_task_correctly.yml
+++ b/spec/fixtures/vcr_cassettes/ChartMogul_Task/API_Actions/creates_a_task_correctly.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.chartmogul.com/v1/tasks
+    body:
+      encoding: UTF-8
+      string: '{"customer_uuid":"cus_9c8cc2bd-762e-4d93-ae34-1cfb53a53f64","task_details":"This
+        is some task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00.000Z"}'
+    headers:
+      User-Agent:
+      - chartmogul-ruby/4.6.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic hidden
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      date:
+      - Fri, 25 Apr 2025 02:15:06 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '338'
+      connection:
+      - keep-alive
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"task_uuid":"1aeae108-217b-11f0-b2b4-5b42f025062c","customer_uuid":"cus_9c8cc2bd-762e-4d93-ae34-1cfb53a53f64","task_details":"This
+        is some task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00.000Z","completed_at":null,"created_at":"2025-04-25T02:15:06.474Z","updated_at":"2025-04-25T02:15:06.474Z"}'
+  recorded_at: Fri, 25 Apr 2025 02:15:06 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/ChartMogul_Task/API_Actions/destroys_the_task_correctly.yml
+++ b/spec/fixtures/vcr_cassettes/ChartMogul_Task/API_Actions/destroys_the_task_correctly.yml
@@ -1,0 +1,31 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.chartmogul.com/v1/tasks/d8c374e0-b9ef-47cf-a5a5-4c71fe0a1466
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - chartmogul-ruby/4.6.0
+      Authorization:
+      - Basic hidden
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Fri, 25 Apr 2025 02:41:12 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '2'
+      connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{}'
+  recorded_at: Fri, 25 Apr 2025 02:41:11 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/ChartMogul_Task/API_Actions/retrieves_a_task_correctly.yml
+++ b/spec/fixtures/vcr_cassettes/ChartMogul_Task/API_Actions/retrieves_a_task_correctly.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/tasks/6c969fee-2179-11f0-8d8c-ef2a5afba642
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - chartmogul-ruby/4.6.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic hidden
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Fri, 25 Apr 2025 02:15:04 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '338'
+      connection:
+      - keep-alive
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"task_uuid":"6c969fee-2179-11f0-8d8c-ef2a5afba642","customer_uuid":"cus_9c8cc2bd-762e-4d93-ae34-1cfb53a53f64","task_details":"This
+        is some task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00.000Z","completed_at":null,"created_at":"2025-04-25T02:03:04.503Z","updated_at":"2025-04-25T02:03:04.503Z"}'
+  recorded_at: Fri, 25 Apr 2025 02:15:04 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/ChartMogul_Task/API_Actions/retrieves_all_tasks_correctly.yml
+++ b/spec/fixtures/vcr_cassettes/ChartMogul_Task/API_Actions/retrieves_all_tasks_correctly.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/tasks?customer_uuid=cus_9c8cc2bd-762e-4d93-ae34-1cfb53a53f64
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - chartmogul-ruby/4.6.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic hidden
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Fri, 25 Apr 2025 02:38:08 GMT
+      content-type:
+      - application/json
+      transfer-encoding:
+      - chunked
+      connection:
+      - keep-alive
+      vary:
+      - Accept-Encoding
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"entries":[{"task_uuid":"6c969fee-2179-11f0-8d8c-ef2a5afba642","customer_uuid":"cus_9c8cc2bd-762e-4d93-ae34-1cfb53a53f64","task_details":"This
+        is some task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00.000Z","completed_at":null,"created_at":"2025-04-25T02:15:06.474Z","updated_at":"2025-04-25T02:15:06.474Z"},{"task_uuid":"ca9ec9c6-217a-11f0-b1e2-6f673dacbb87","customer_uuid":"cus_9c8cc2bd-762e-4d93-ae34-1cfb53a53f64","task_details":"This
+        is some task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00.000Z","completed_at":null,"created_at":"2025-04-25T02:12:51.757Z","updated_at":"2025-04-25T02:12:51.757Z"},{"task_uuid":"6c969fee-2179-11f0-8d8c-ef2a5afba642","customer_uuid":"cus_9c8cc2bd-762e-4d93-ae34-1cfb53a53f64","task_details":"This
+        is some task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00.000Z","completed_at":null,"created_at":"2025-04-25T02:03:04.503Z","updated_at":"2025-04-25T02:03:04.503Z"},{"task_uuid":"6bedc144-2179-11f0-9074-47237186e386","customer_uuid":"cus_9c8cc2bd-762e-4d93-ae34-1cfb53a53f64","task_details":"This
+        is some task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00.000Z","completed_at":null,"created_at":"2025-04-25T02:03:03.396Z","updated_at":"2025-04-25T02:03:03.396Z"},{"task_uuid":"275bc0bc-2179-11f0-897b-f3e70d2aa58d","customer_uuid":"cus_9c8cc2bd-762e-4d93-ae34-1cfb53a53f64","task_details":"This
+        is some task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00.000Z","completed_at":null,"created_at":"2025-04-25T02:01:08.353Z","updated_at":"2025-04-25T02:01:08.353Z"}],"cursor":"MjAyNS0wNC0yNVQwMjowMTowOC4zNTM0NDEwMDBaJjI3NWJjMGJjLTIxNzktMTFmMC04OTdiLWYzZTcwZDJhYTU4ZA==","has_more":false}'
+  recorded_at: Fri, 25 Apr 2025 02:38:07 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/ChartMogul_Task/API_Actions/updates_the_task_correctly_with_the_class_method.yml
+++ b/spec/fixtures/vcr_cassettes/ChartMogul_Task/API_Actions/updates_the_task_correctly_with_the_class_method.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://api.chartmogul.com/v1/tasks/6c969fee-2179-11f0-8d8c-ef2a5afba642
+    body:
+      encoding: UTF-8
+      string: '{"task_details":"This is updated task details text."}'
+    headers:
+      User-Agent:
+      - chartmogul-ruby/4.6.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic hidden
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Fri, 25 Apr 2025 02:47:57 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '341'
+      connection:
+      - keep-alive
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"task_uuid":"6c969fee-2179-11f0-8d8c-ef2a5afba642","customer_uuid":"cus_9c8cc2bd-762e-4d93-ae34-1cfb53a53f64","task_details":"This
+        is updated task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00.000Z","completed_at":null,"created_at":"2025-04-25T02:03:04.503Z","updated_at":"2025-04-25T02:47:57.793Z"}'
+  recorded_at: Fri, 25 Apr 2025 02:47:57 GMT
+recorded_with: VCR 6.3.1

--- a/spec/fixtures/vcr_cassettes/ChartMogul_Task/API_Actions/with_pagination/paginates_correctly.yml
+++ b/spec/fixtures/vcr_cassettes/ChartMogul_Task/API_Actions/with_pagination/paginates_correctly.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/tasks?per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - chartmogul-ruby/4.6.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic hidden
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Fri, 25 Apr 2025 03:05:23 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '472'
+      connection:
+      - keep-alive
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"entries":[{"task_uuid":"1aeae108-217b-11f0-b2b4-5b42f025062c","customer_uuid":"cus_9c8cc2bd-762e-4d93-ae34-1cfb53a53f64","task_details":"This
+        is some task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00.000Z","completed_at":null,"created_at":"2025-04-25T02:15:06.474Z","updated_at":"2025-04-25T02:15:06.474Z"}],"cursor":"MjAyNS0wNC0yNVQwMjoxNTowNi40NzQzNTQwMDBaJjFhZWFlMTA4LTIxN2ItMTFmMC1iMmI0LTViNDJmMDI1MDYyYw==","has_more":true}'
+  recorded_at: Fri, 25 Apr 2025 03:05:23 GMT
+- request:
+    method: get
+    uri: https://api.chartmogul.com/v1/tasks?cursor=MjAyNS0wNC0yNVQwMjoxNTowNi40NzQzNTQwMDBaJjFhZWFlMTA4LTIxN2ItMTFmMC1iMmI0LTViNDJmMDI1MDYyYw%3D%3D&customer_uuid=cus_9c8cc2bd-762e-4d93-ae34-1cfb53a53f64&per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - chartmogul-ruby/4.6.0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Basic hidden
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      date:
+      - Fri, 25 Apr 2025 03:05:24 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '472'
+      connection:
+      - keep-alive
+      access-control-allow-credentials:
+      - 'true'
+    body:
+      encoding: UTF-8
+      string: '{"entries":[{"task_uuid":"6c969fee-2179-11f0-8d8c-ef2a5afba642","customer_uuid":"cus_9c8cc2bd-762e-4d93-ae34-1cfb53a53f64","task_details":"This
+        is some task details text.","assignee":"keith+test1@chartmogul.com","due_date":"2025-04-30T00:00:00.000Z","completed_at":null,"created_at":"2025-04-25T02:12:51.757Z","updated_at":"2025-04-25T02:12:51.757Z"}],"cursor":"MjAyNS0wNC0yNVQwMjoxMjo1MS43NTc5NTcwMDBaJmNhOWVjOWM2LTIxN2EtMTFmMC1iMWUyLTZmNjczZGFjYmI4Nw==","has_more":false}'
+  recorded_at: Fri, 25 Apr 2025 03:05:24 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
This PR adds support for the Tasks API to the SDK.

The spec for this project can be found [here](https://www.notion.so/chartmogul/API-for-Tasks-c87a8c8de97d495a92bf7266c49ff6ec).

## Customer Additions

**Create a task for a customer**

```ruby
customer = ChartMogul::Customer.retrieve('cus_3819e09a-50a2-11ee-ada7-9fcf71cd4580')
customer.create_task({ ... })
```

**List all tasks for a customer**

```ruby
customer = ChartMogul::Customer.retrieve('cus_3819e09a-50a2-11ee-ada7-9fcf71cd4580')
customer.tasks
```

## Task Additions

**Get all tasks**

```ruby
tasks = ChartMogul::Task.all(customer_uuid: customer_uuid)
```

**Get a task**

```ruby
task = ChartMogul::Task.retrieve('task_uuid')
```

**Create a task**

```ruby
new_task = ChartMogul::Task.create({ customer_uuid: customer_uuid, ... })
```

**Update a task**

```ruby
updated_task = ChartMogul::Task.update({ ... })
```

**Delete a task**

```ruby
ChartMogul::Task.delete('task_uuid') 
```