### PR TITLE
Add MrrIntervalEdit to CSV module

### DIFF
--- a/lib/chartmogul.rb
+++ b/lib/chartmogul.rb
@@ -85,6 +85,7 @@ require 'chartmogul/csv/transaction'
 require 'chartmogul/csv/cancellation'
 require 'chartmogul/csv/subscription_connection'
 require 'chartmogul/csv/subscription_event'
+require 'chartmogul/csv/mrr_interval_edit'
 
 require 'chartmogul/csv/uploads/base'
 require 'chartmogul/csv/uploads/job'

--- a/lib/chartmogul/csv/mrr_interval_edit.rb
+++ b/lib/chartmogul/csv/mrr_interval_edit.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module ChartMogul
+  module CSV
+    class MrrIntervalEdit < Base
+      CONNECTION_HEADERS = %w[Account\ ID Billing\ Connector\ ID Customer\ External\ ID Subscription\ External\ ID Subscription\ Activation\ Number Interval\ Start\ Date Edited\ MRR Timestamp Auth\ User\ ID Email Edit\ Type].freeze
+
+      writeable_attr :account_id
+      writeable_attr :billing_connector_id
+      writeable_attr :customer_external_id
+      writeable_attr :subscription_external_id
+      writeable_attr :subscription_activation_number
+      writeable_attr :interval_start_date
+      writeable_attr :edited_mrr
+      writeable_attr :timestamp
+      writeable_attr :auth_user_id
+      writeable_attr :email
+      writeable_attr :edit_type
+
+      def self.headers
+        CONNECTION_HEADERS
+      end
+    end
+  end
+end

--- a/spec/chartmogul/csv/mrr_interval_edit_spec.rb
+++ b/spec/chartmogul/csv/mrr_interval_edit_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ChartMogul::CSV::MrrIntervalEdit do
+  describe '#initialize' do
+    subject(:mrr_edit) do
+      described_class.new(
+        account_id: 1,
+        billing_connector_id: 1,
+        customer_external_id: 'cus-123',
+        subscription_external_id: 'sub-456',
+        subscription_activation_number: 1,
+        interval_start_date: Time.new(2025, 9, 12),
+        edited_mrr: 1000,
+        timestamp: Time.new(2025, 9, 12, 12),
+        auth_user_id: 1,
+        email: 'user@example.com',
+        edit_type: 'manual_adjustment'
+      )
+    end
+
+    it 'sets correctly all attributes' do
+      expect(mrr_edit.account_id).to eq(1)
+      expect(mrr_edit.billing_connector_id).to eq(1)
+      expect(mrr_edit.customer_external_id).to eq('cus-123')
+      expect(mrr_edit.subscription_external_id).to eq('sub-456')
+      expect(mrr_edit.subscription_activation_number).to eq(1)
+      expect(mrr_edit.interval_start_date).to eq(Time.new(2025, 9, 12))
+      expect(mrr_edit.edited_mrr).to eq(1000)
+      expect(mrr_edit.timestamp).to eq(Time.new(2025, 9, 12, 12))
+      expect(mrr_edit.auth_user_id).to eq(1)
+      expect(mrr_edit.email).to eq('user@example.com')
+      expect(mrr_edit.edit_type).to eq('manual_adjustment')
+    end
+
+    it 'returns the correct headers' do
+      expect(described_class.headers)
+        .to eq(
+          [
+            'Account ID',
+            'Billing Connector ID',
+            'Customer External ID',
+            'Subscription External ID',
+            'Subscription Activation Number',
+            'Interval Start Date',
+            'Edited MRR',
+            'Timestamp',
+            'Auth User ID',
+            'Email',
+            'Edit Type'
+          ]
+        )
+    end
+  end
+end


### PR DESCRIPTION
Adds a mapping for `mrr_interval_edits` which will be used by the generic import tool (see https://github.com/chartmogul/platform/pull/26485)