### PR TITLE
Add immutable release enforcement and security docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        with:
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 |
 <b><a href="#contributing">Contributing</a></b>
 |
+<b><a href="#security">Security</a></b>
+|
 <b><a href="#license">License</a></b>
 </p>
 
@@ -35,8 +37,10 @@
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'chartmogul-ruby', require: 'chartmogul'
+gem 'chartmogul-ruby', '~> 4.13', require: 'chartmogul'
 ```
+
+We recommend pinning to a specific version as shown above. Bundler records exact versions and checksums in your `Gemfile.lock`, ensuring reproducible installs.
 
 And then execute:
 
@@ -118,6 +122,17 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/chartmogul/chartmogul-ruby.
+
+## Security
+
+### Verifying Releases
+
+All releases of this library are published as [immutable GitHub Releases](https://github.com/chartmogul/chartmogul-ruby/releases) with protected tags and as a gem on [RubyGems.org](https://rubygems.org/gems/chartmogul-ruby).
+
+To maximize supply chain security:
+- **Pin to a specific version** in your Gemfile: `gem 'chartmogul-ruby', '~> 4.13'`
+- **Commit your `Gemfile.lock`** to version control
+- **Verify gem checksums** with `bundle install` (Bundler 2.x+ records checksums automatically)
 
 ## License
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,72 @@
+# Releasing chartmogul-ruby
+
+## Prerequisites
+
+- You must have push access to the repository
+- Tags matching `v*` are protected by GitHub tag protection rulesets
+- Releases are immutable once published (GitHub repository setting)
+
+## Release Process
+
+1. Ensure all changes are merged to the `main` branch
+2. Ensure CI is green on the `main` branch
+3. Update the version in `lib/chartmogul/version.rb`
+4. Update the `CHANGELOG.md` if applicable
+5. Commit the version bump
+6. Create and push a version tag:
+   ```sh
+   git tag v4.X.Y
+   git push origin v4.X.Y
+   ```
+7. The [release workflow](.github/workflows/release.yml) will automatically create a GitHub Release with auto-generated release notes
+8. Verify the release appears at https://github.com/chartmogul/chartmogul-ruby/releases
+9. Build and push the gem to RubyGems:
+   ```sh
+   gem build chartmogul-ruby.gemspec
+   gem push chartmogul-ruby-4.X.Y.gem
+   ```
+
+## Changelog
+
+Release notes are auto-generated from merged PR titles by the [release workflow](.github/workflows/release.yml). To ensure useful changelogs:
+
+- Use clear, descriptive PR titles (e.g., "Add External ID field to Contact model")
+- Prefix breaking changes with `BREAKING:` so they stand out in release notes
+- After the release is created, review and edit the notes on the [Releases page](https://github.com/chartmogul/chartmogul-ruby/releases) if needed
+
+## Pre-release Versions
+
+For pre-release versions, use a semver pre-release suffix:
+
+```sh
+git tag v4.X.Y-rc1
+git push origin v4.X.Y-rc1
+```
+
+These will be automatically marked as pre-releases on GitHub.
+
+## Security
+
+### Repository Protections
+
+- **Immutable releases**: Once a GitHub Release is published, its tag cannot be moved or deleted, and release assets cannot be modified
+- **Tag protection rulesets**: `v*` tags cannot be deleted or force-pushed
+
+### RubyGems
+
+- [RubyGems.org](https://rubygems.org) enforces version immutability: once a gem version is published, it cannot be overwritten
+- Users can verify gem integrity using `gem cert` or Bundler checksums
+- Bundler 2.x+ records gem checksums in `Gemfile.lock` for reproducible installs
+
+### What This Protects Against
+
+- A compromised maintainer account cannot modify or delete existing releases
+- Tags cannot be moved to point to different commits after publication
+- RubyGems version immutability provides an independent verification layer beyond GitHub
+
+### Repository Settings (Admin)
+
+These settings must be configured by a repository admin:
+
+1. **Immutable Releases**: Settings > General > Releases > Enable "Immutable releases"
+2. **Tag Protection Ruleset**: Settings > Rules > Rulesets > New ruleset targeting tags matching `v*` with deletion and force-push prevention


### PR DESCRIPTION
## Summary

- Add release workflow (`.github/workflows/release.yml`) that auto-creates GitHub Releases on `v*` tag push with auto-generated release notes
- Update README installation to recommend pinned versions (`~> 4.13`), add Security section explaining checksum verification
- Add `RELEASING.md` documenting the release process, changelog conventions, and security protections

Closes https://linear.app/chartmogul/issue/OME-543

## Admin steps required

After merging, a repository admin should:

1. **Enable Immutable Releases**: Settings → General → Releases → Enable "Immutable releases"
2. **Add Tag Protection Ruleset**: Settings → Rules → Rulesets → New ruleset targeting tags matching `v*` with deletion and force-push prevention

## Test plan

- [ ] Verify `release.yml` passes zizmor linting on this PR
- [ ] After merging + enabling immutable releases, push a test tag (e.g., `v4.14.0-rc1`) and confirm a GitHub Release is created automatically
- [ ] Confirm the release is marked as pre-release and has auto-generated notes
- [ ] Verify the release tag cannot be deleted after enabling immutable releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)