### PR TITLE
Rework Claude Code hooks and gitignore build artifacts

### DIFF
--- a/.claude/hooks/post-edit-lint.sh
+++ b/.claude/hooks/post-edit-lint.sh
@@ -6,8 +6,7 @@ FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
 # Only track .rb files, skip vendored/generated paths
 if [[ "$FILE" == *.rb ]] && [[ "$FILE" != */vendor/* ]] && [[ "$FILE" != */coverage/* ]]; then
-  TRACKER="/tmp/claude-edited-rb-files.$$"
-  # Append and dedup
+  TRACKER="/tmp/claude-edited-rb-files-${CLAUDE_HOOK_SESSION_ID:-default}"
   echo "$FILE" >> "$TRACKER"
   sort -u "$TRACKER" -o "$TRACKER"
 fi

--- a/.claude/hooks/post-edit-lint.sh
+++ b/.claude/hooks/post-edit-lint.sh
@@ -4,8 +4,6 @@ FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
 if [[ "$FILE" == *.rb ]]; then
   bundle exec rubocop -a "$FILE" 2>/dev/null
-  bundle exec rspec 2>&1
-  gem build chartmogul-ruby.gemspec 2>&1
 fi
 
 exit 0

--- a/.claude/hooks/post-edit-lint.sh
+++ b/.claude/hooks/post-edit-lint.sh
@@ -5,6 +5,7 @@ FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 if [[ "$FILE" == *.rb ]]; then
   bundle exec rubocop -a "$FILE" 2>/dev/null
   bundle exec rspec 2>&1
+  gem build chartmogul-ruby.gemspec 2>&1
 fi
 
 exit 0

--- a/.claude/hooks/post-edit-lint.sh
+++ b/.claude/hooks/post-edit-lint.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
 INPUT=$(cat)
 FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
-if [[ "$FILE" == *.rb ]]; then
-  bundle exec rubocop -a "$FILE" 2>/dev/null
+# Only track .rb files, skip vendored/generated paths
+if [[ "$FILE" == *.rb ]] && [[ "$FILE" != */vendor/* ]] && [[ "$FILE" != */coverage/* ]]; then
+  TRACKER="/tmp/claude-edited-rb-files.$$"
+  # Append and dedup
+  echo "$FILE" >> "$TRACKER"
+  sort -u "$TRACKER" -o "$TRACKER"
 fi
 
 exit 0

--- a/.claude/hooks/post-stop-validate.sh
+++ b/.claude/hooks/post-stop-validate.sh
@@ -1,34 +1,31 @@
 #!/bin/bash
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
-TRACKER="/tmp/claude-edited-rb-files.$$"
-
-# Nothing tracked this turn - skip
-if [[ ! -f "$TRACKER" ]]; then
-  exit 0
-fi
-
-files=$(cat "$TRACKER")
-rm -f "$TRACKER"
-
-if [[ -z "$files" ]]; then
-  exit 0
-fi
-
-# Batch rubocop autocorrect on all edited files
-rubocop_out=$(echo "$files" | xargs bundle exec rubocop -a 2>&1) || true
-offenses=$(echo "$rubocop_out" | grep -E "^.+:\d+:\d+:" | head -20)
-
-# Fast test suite (~1s)
-rspec_out=$(bundle exec rspec 2>&1) || true
-failures=$(echo "$rspec_out" | grep -E "^rspec .+ --failures|^\s+\d+\) " | head -20)
+TRACKER="/tmp/claude-edited-rb-files-${CLAUDE_HOOK_SESSION_ID:-default}"
 
 ctx=""
-if [[ -n "$offenses" ]]; then
-  ctx+="rubocop offenses remaining after autocorrect:\n$offenses\n"
+
+# Batch rubocop autocorrect on tracked files (if any were edited)
+if [[ -f "$TRACKER" ]]; then
+  files=$(cat "$TRACKER")
+  rm -f "$TRACKER"
+
+  if [[ -n "$files" ]]; then
+    rubocop_out=$(echo "$files" | xargs bundle exec rubocop -a 2>&1) || true
+    offenses=$(echo "$rubocop_out" | grep -E "^.+:[0-9]+:[0-9]+:" | head -20)
+    if [[ -n "$offenses" ]]; then
+      ctx+="rubocop offenses remaining after autocorrect:\n$offenses\n"
+    fi
+  fi
 fi
-if [[ -n "$failures" ]]; then
-  ctx+="rspec failures:\n$failures\n"
+
+# Always run rspec - edits to specs or lib code both matter (~1s)
+rspec_out=$(bundle exec rspec 2>&1)
+rspec_exit=$?
+if [[ $rspec_exit -ne 0 ]]; then
+  summary=$(echo "$rspec_out" | grep -E "[0-9]+ examples?, [0-9]+ failures?" | tail -1)
+  failed=$(echo "$rspec_out" | grep -E "^rspec .+" | head -10)
+  ctx+="rspec failed ($summary):\n$failed\n"
 fi
 
 if [[ -n "$ctx" ]]; then

--- a/.claude/hooks/post-stop-validate.sh
+++ b/.claude/hooks/post-stop-validate.sh
@@ -1,6 +1,33 @@
 #!/bin/bash
-bundle exec rubocop 2>&1
-bundle exec rspec 2>&1
-gem build chartmogul-ruby.gemspec 2>&1
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+TRACKER="/tmp/claude-edited-rb-files.$$"
+
+# Nothing tracked this turn - skip
+if [[ ! -f "$TRACKER" ]]; then
+  exit 0
+fi
+
+files=$(cat "$TRACKER")
+rm -f "$TRACKER"
+
+if [[ -z "$files" ]]; then
+  exit 0
+fi
+
+# Batch rubocop autocorrect on all edited files
+output=$(echo "$files" | xargs bundle exec rubocop -a 2>&1) || true
+
+# Filter to remaining offenses only (skip clean output)
+offenses=$(echo "$output" | grep -E "^.+:\d+:\d+:" | head -20)
+
+if [[ -n "$offenses" ]]; then
+  jq -n --arg ctx "rubocop offenses remaining after autocorrect:\n$offenses" '{
+    "hookSpecificOutput": {
+      "hookEventName": "Stop",
+      "additionalContext": $ctx
+    }
+  }'
+fi
 
 exit 0

--- a/.claude/hooks/post-stop-validate.sh
+++ b/.claude/hooks/post-stop-validate.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+bundle exec rubocop 2>&1
 bundle exec rspec 2>&1
 gem build chartmogul-ruby.gemspec 2>&1
 

--- a/.claude/hooks/post-stop-validate.sh
+++ b/.claude/hooks/post-stop-validate.sh
@@ -16,13 +16,23 @@ if [[ -z "$files" ]]; then
 fi
 
 # Batch rubocop autocorrect on all edited files
-output=$(echo "$files" | xargs bundle exec rubocop -a 2>&1) || true
+rubocop_out=$(echo "$files" | xargs bundle exec rubocop -a 2>&1) || true
+offenses=$(echo "$rubocop_out" | grep -E "^.+:\d+:\d+:" | head -20)
 
-# Filter to remaining offenses only (skip clean output)
-offenses=$(echo "$output" | grep -E "^.+:\d+:\d+:" | head -20)
+# Fast test suite (~1s)
+rspec_out=$(bundle exec rspec 2>&1) || true
+failures=$(echo "$rspec_out" | grep -E "^rspec .+ --failures|^\s+\d+\) " | head -20)
 
+ctx=""
 if [[ -n "$offenses" ]]; then
-  jq -n --arg ctx "rubocop offenses remaining after autocorrect:\n$offenses" '{
+  ctx+="rubocop offenses remaining after autocorrect:\n$offenses\n"
+fi
+if [[ -n "$failures" ]]; then
+  ctx+="rspec failures:\n$failures\n"
+fi
+
+if [[ -n "$ctx" ]]; then
+  jq -n --arg ctx "$ctx" '{
     "hookSpecificOutput": {
       "hookEventName": "Stop",
       "additionalContext": $ctx

--- a/.claude/hooks/post-stop-validate.sh
+++ b/.claude/hooks/post-stop-validate.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+bundle exec rspec 2>&1
+gem build chartmogul-ruby.gemspec 2>&1
+
+exit 0

--- a/.claude/hooks/session-start-setup.sh
+++ b/.claude/hooks/session-start-setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+bundle install 2>&1
+
+exit 0

--- a/.claude/hooks/session-start-setup.sh
+++ b/.claude/hooks/session-start-setup.sh
@@ -1,4 +1,32 @@
 #!/bin/bash
-bundle install 2>&1
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+ctx=""
+
+# Warn if Gemfile is newer than Gemfile.lock (deps out of date)
+if [[ -f Gemfile.lock && Gemfile -nt Gemfile.lock ]]; then
+  ctx+="Gemfile.lock is stale - run bundle install before testing.\n"
+fi
+
+# Warn about uncommitted changes
+dirty=$(git diff --name-only 2>/dev/null | head -5)
+if [[ -n "$dirty" ]]; then
+  ctx+="Uncommitted changes:\n$dirty\n"
+fi
+
+# Report current branch
+branch=$(git branch --show-current 2>/dev/null)
+if [[ -n "$branch" ]]; then
+  ctx+="Branch: $branch\n"
+fi
+
+if [[ -n "$ctx" ]]; then
+  jq -n --arg ctx "$ctx" '{
+    "hookSpecificOutput": {
+      "hookEventName": "SessionStart",
+      "additionalContext": $ctx
+    }
+  }'
+fi
 
 exit 0

--- a/.claude/hooks/session-start-setup.sh
+++ b/.claude/hooks/session-start-setup.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
+# Generate a stable session ID and persist via CLAUDE_ENV_FILE
+# so the edit tracker and stop hook share the same file path
+SESSION_ID="$(date +%s)-$$"
+if [[ -n "$CLAUDE_ENV_FILE" ]]; then
+  echo "export CLAUDE_HOOK_SESSION_ID='$SESSION_ID'" >> "$CLAUDE_ENV_FILE"
+fi
+
 ctx=""
 
-# Warn if Gemfile is newer than Gemfile.lock (deps out of date)
-if [[ -f Gemfile.lock && Gemfile -nt Gemfile.lock ]]; then
+# Warn if Gemfile.lock is missing or stale
+if [[ ! -f Gemfile.lock ]]; then
+  ctx+="Gemfile.lock missing - run bundle install.\n"
+elif [[ Gemfile -nt Gemfile.lock ]]; then
   ctx+="Gemfile.lock is stale - run bundle install before testing.\n"
 fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,16 @@
     ]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/session-start-setup.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,6 +37,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./.claude/hooks/post-stop-validate.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,7 +39,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /spec/reports/
 /tmp/
 *.swp
+*.gem
 vendor/bundle
 /.idea
 .DS_Store


### PR DESCRIPTION
Follow-up to #195.

- Reworked hooks to keep the edit path fast and push slow checks to end-of-turn
- Added *.gem to .gitignore to prevent build artifacts from being committed
- Hooks share a stable session ID via CLAUDE_ENV_FILE so the file tracker works across invocations

## Hooks

| Hook | Event | Budget | What it does |
|------|-------|--------|-------------|
| `session-start-setup.sh` | SessionStart | <1s | Generates stable session ID for tracker. Warns if Gemfile.lock is missing or stale, reports uncommitted changes and branch. No network, no installs. |
| `post-edit-lint.sh` | PostToolUse (Edit/Write/MultiEdit) | <50ms | Records edited .rb file path to a session-scoped temp tracker. Deduplicates, skips vendor/coverage. No lint, no git. |
| `post-stop-validate.sh` | Stop | once/turn | Batch rubocop autocorrect on tracked files, then runs rspec unconditionally (~1s). Reports remaining offenses and test failures as context for the next prompt. Silent on clean runs. |

## Manually tested
- SessionStart: reports branch, persists session ID via CLAUDE_ENV_FILE
- PostToolUse: tracks .rb files, deduplicates, skips vendor/ and non-.rb
- Stop: rubocop runs on tracked files only, rspec runs unconditionally
- Stop: test failures surface with summary and failing spec path
- Stop: tracker file cleaned up after run
- Stop: no tracked files = rspec only, no rubocop, no error
- Multiple sessions get different tracker files via unique session ID

## Test plan
- Start a new session, confirm branch and lockfile status surfaces
- Edit multiple .rb files in one turn, confirm rubocop runs once at the end
- Introduce a failing spec, confirm it surfaces as context in the next prompt
- Run gem build manually, confirm the .gem file is gitignored