### PR TITLE
Rework Claude Code hooks and scope gh permissions

### DIFF
--- a/.claude/hooks/post-edit-lint.sh
+++ b/.claude/hooks/post-edit-lint.sh
@@ -6,7 +6,7 @@ FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
 # Only track .rb files, skip vendored/generated paths
 if [[ "$FILE" == *.rb ]] && [[ "$FILE" != */vendor/* ]] && [[ "$FILE" != */coverage/* ]]; then
-  TRACKER="/tmp/claude-edited-rb-files-${CLAUDE_HOOK_SESSION_ID:-default}"
+  TRACKER="${TMPDIR:-/tmp}/claude-edited-rb-files-${CLAUDE_HOOK_SESSION_ID:-default}"
   echo "$FILE" >> "$TRACKER"
   sort -u "$TRACKER" -o "$TRACKER"
 fi

--- a/.claude/hooks/post-stop-validate.sh
+++ b/.claude/hooks/post-stop-validate.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
-TRACKER="/tmp/claude-edited-rb-files-${CLAUDE_HOOK_SESSION_ID:-default}"
+TRACKER="${TMPDIR:-/tmp}/claude-edited-rb-files-${CLAUDE_HOOK_SESSION_ID:-default}"
 
 ctx=""
+had_edits=false
 
 # Batch rubocop autocorrect on tracked files (if any were edited)
 if [[ -f "$TRACKER" ]]; then
@@ -11,6 +12,7 @@ if [[ -f "$TRACKER" ]]; then
   rm -f "$TRACKER"
 
   if [[ -n "$files" ]]; then
+    had_edits=true
     rubocop_out=$(echo "$files" | xargs bundle exec rubocop -a 2>&1) || true
     offenses=$(echo "$rubocop_out" | grep -E "^.+:[0-9]+:[0-9]+:" | head -20)
     if [[ -n "$offenses" ]]; then
@@ -19,13 +21,15 @@ if [[ -f "$TRACKER" ]]; then
   fi
 fi
 
-# Always run rspec - edits to specs or lib code both matter (~1s)
-rspec_out=$(bundle exec rspec 2>&1)
-rspec_exit=$?
-if [[ $rspec_exit -ne 0 ]]; then
-  summary=$(echo "$rspec_out" | grep -E "[0-9]+ examples?, [0-9]+ failures?" | tail -1)
-  failed=$(echo "$rspec_out" | grep -E "^rspec .+" | head -10)
-  ctx+="rspec failed ($summary):\n$failed\n"
+# Only run rspec if files were edited (~1s)
+if [[ "$had_edits" == true ]]; then
+  rspec_out=$(bundle exec rspec 2>&1)
+  rspec_exit=$?
+  if [[ $rspec_exit -ne 0 ]]; then
+    summary=$(echo "$rspec_out" | grep -E "[0-9]+ examples?, [0-9]+ failures?" | tail -1)
+    failed=$(echo "$rspec_out" | grep -E "^rspec .+" | head -10)
+    ctx+="rspec failed ($summary):\n$failed\n"
+  fi
 fi
 
 if [[ -n "$ctx" ]]; then

--- a/.claude/hooks/session-start-setup.sh
+++ b/.claude/hooks/session-start-setup.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 
-# Generate a stable session ID and persist via CLAUDE_ENV_FILE
+# Read session_id from hook input and persist via CLAUDE_ENV_FILE
 # so the edit tracker and stop hook share the same file path
-SESSION_ID="$(date +%s)-$$"
-if [[ -n "$CLAUDE_ENV_FILE" ]]; then
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+if [[ -n "$SESSION_ID" ]] && [[ -n "$CLAUDE_ENV_FILE" ]]; then
   echo "export CLAUDE_HOOK_SESSION_ID='$SESSION_ID'" >> "$CLAUDE_ENV_FILE"
 fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,11 +19,36 @@
       "Bash(git pull:*)",
       "Bash(git cherry-pick:*)",
       "Bash(git reset:*)",
-      "Bash(gh pr:*)",
-      "Bash(gh api:*)"
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr status:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run watch:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh release view:*)",
+      "Bash(gh release list:*)",
+      "Bash(gh repo view:*)",
+      "Bash(gh search:*)",
+      "Bash(gh api * --method GET *)",
+      "Bash(gh api * --jq *)"
     ],
     "deny": [
       "Read(./.env*)"
+    ],
+    "ask": [
+      "Bash(gh pr create:*)",
+      "Bash(gh pr edit:*)",
+      "Bash(gh pr comment:*)",
+      "Bash(gh pr close:*)",
+      "Bash(gh pr ready:*)",
+      "Bash(gh pr merge:*)",
+      "Bash(gh api * -X POST *)",
+      "Bash(gh api * --method POST *)",
+      "Bash(gh api * -f *)"
     ]
   },
   "hooks": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,14 +36,6 @@
     ],
     "deny": [
       "Read(./.env*)"
-    ],
-    "ask": [
-      "Bash(gh pr create:*)",
-      "Bash(gh pr edit:*)",
-      "Bash(gh pr comment:*)",
-      "Bash(gh pr close:*)",
-      "Bash(gh pr ready:*)",
-      "Bash(gh pr merge:*)"
     ]
   },
   "hooks": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,9 +32,7 @@
       "Bash(gh release view:*)",
       "Bash(gh release list:*)",
       "Bash(gh repo view:*)",
-      "Bash(gh search:*)",
-      "Bash(gh api * --method GET *)",
-      "Bash(gh api * --jq *)"
+      "Bash(gh search:*)"
     ],
     "deny": [
       "Read(./.env*)"
@@ -45,10 +43,7 @@
       "Bash(gh pr comment:*)",
       "Bash(gh pr close:*)",
       "Bash(gh pr ready:*)",
-      "Bash(gh pr merge:*)",
-      "Bash(gh api * -X POST *)",
-      "Bash(gh api * --method POST *)",
-      "Bash(gh api * -f *)"
+      "Bash(gh pr merge:*)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary

- Rework Claude Code hooks into a three-stage pipeline: session start (bundle check, branch context), post-edit (track edited .rb files), and stop (batched rubocop autocorrect + rspec)
- Scope `gh` permissions in `.claude/settings.json` - read-only commands (view, list, diff, checks, status, search) are auto-allowed, everything else prompts for confirmation
- Apply review feedback from chartmogul-node#138: use `session_id` from hook input, respect `$TMPDIR`, skip rspec when no files were edited

## Test plan

- Start a new Claude Code session in this repo and verify the SessionStart hook reports branch and bundle status
- Edit a `.rb` file and confirm post-edit tracking works (check `$TMPDIR/claude-edited-rb-files-*` exists)
- On session stop with edits, verify rubocop runs on tracked files and rspec executes
- On session stop without edits, verify neither rubocop nor rspec run
- Run `gh pr list` and confirm it executes without prompting
- Run `gh pr create --help` and confirm it prompts for confirmation