### PR TITLE
Deprecate Subscription.all and Subscriptions.all import endpoint methods

### DIFF
--- a/lib/chartmogul/subscription.rb
+++ b/lib/chartmogul/subscription.rb
@@ -42,6 +42,7 @@ module ChartMogul
     end
 
     def self.all(customer_uuid, options = {})
+      warn 'DEPRECATION WARNING: the method ChartMogul::Subscription.all is deprecated. Use ChartMogul::Metrics::Customers::Subscriptions.all instead.'
       Subscriptions.all(customer_uuid, options)
     end
 
@@ -71,6 +72,7 @@ module ChartMogul
     set_entry_class Subscription
 
     def self.all(customer_uuid, options = {})
+      warn 'DEPRECATION WARNING: the method ChartMogul::Subscriptions.all is deprecated. Use ChartMogul::Metrics::Customers::Subscriptions.all instead.'
       super(options.merge(customer_uuid: customer_uuid))
     end
 


### PR DESCRIPTION
Linear: [PIP-40](https://linear.app/chartmogul/issue/PIP-40/deprecate-import-subscriptions-api-endpoint-in-libraries)

- Adds a `warn` deprecation notice to `ChartMogul::Subscription.all` and `ChartMogul::Subscriptions.all`, both of which call the deprecated import endpoint `/v1/import/customers/:customer_uuid/subscriptions`.
- Directs users to `ChartMogul::Metrics::Customers::Subscriptions.all` as the replacement, matching the existing deprecation pattern already used for `#connect` and `#disconnect` in the same file.

